### PR TITLE
unique(c(...)) instead of c(unique(...))

### DIFF
--- a/R/ch_list_globals.R
+++ b/R/ch_list_globals.R
@@ -205,7 +205,7 @@ print_globals <- function(globals, path = ".", ..., message = TRUE) {
     paste(., collapse = ", \n") %>%
     paste0("--- Potential GlobalVariables ---\n",
            "-- code to copy to your globals.R file --\n\n",
-           "globalVariables(c(unique(\n", ., "\n)))")
+           "globalVariables(unique(c(\n", ., "\n)))")
 
     if (isTRUE(message)) {
       message(glue(liste_funs, "\n", liste_globals))

--- a/tests/testthat/test-checkhelper.R
+++ b/tests/testthat/test-checkhelper.R
@@ -68,7 +68,7 @@ test_that("print_outputs works", {
   )
   expect_equal(
     print_outputs$liste_globals,
-    "--- Potential GlobalVariables ---\n-- code to copy to your globals.R file --\n\nglobalVariables(c(unique(\n# my_fun: \n\"new_col\", \"x\", \"y\", \n# my_median: \n\"data\", \"new_col2\", \"x\", \"y\"\n)))"
+    "--- Potential GlobalVariables ---\n-- code to copy to your globals.R file --\n\nglobalVariables(unique(c(\n# my_fun: \n\"new_col\", \"x\", \"y\", \n# my_median: \n\"data\", \"new_col2\", \"x\", \"y\"\n)))"
   )
   expect_message(print_globals(globals, message = TRUE))
 })


### PR DESCRIPTION
`c(unique("a", "b"))` gives an error

but

`unique(c("a", "b"))` is fine