### PR TITLE
Fix typo in print_globals

### DIFF
--- a/R/ch_list_globals.R
+++ b/R/ch_list_globals.R
@@ -209,7 +209,7 @@ print_globals <- function(globals, path = ".", ..., message = TRUE) {
     ) %>%
     pull(text) %>%
     paste(., collapse = "") %>%
-    paste0("--- Fonctions to add in NAMESPACE (with @importFrom ?) ---\n\n", .)
+    paste0("--- Functions to add in NAMESPACE (with @importFrom ?) ---\n\n", .)
 
   liste_globals <- globals[["globalVariables"]] %>%
     group_by(fun) %>%

--- a/tests/testthat/test-checkhelper.R
+++ b/tests/testthat/test-checkhelper.R
@@ -45,7 +45,7 @@ print_outputs <- print_globals(globals, message = FALSE)
 test_that("print_outputs works", {
   expect_equal(
     print_outputs$liste_funs,
-    "--- Fonctions to add in NAMESPACE (with @importFrom ?) ---\n\nmy_long_fun_name_for_multiple_lines_globals: %>%, aes, geom_point, ggplot, mutate\nmy_plot: %>%, aes, geom_point, ggplot, mutate\nmy_plot_rdname: %>%, aes, geom_point, ggplot, mutate\n"
+    "--- Functions to add in NAMESPACE (with @importFrom ?) ---\n\nmy_long_fun_name_for_multiple_lines_globals: %>%, aes, geom_point, ggplot, mutate\nmy_plot: %>%, aes, geom_point, ggplot, mutate\nmy_plot_rdname: %>%, aes, geom_point, ggplot, mutate\n"
   )
   expect_equal(
     print_outputs$liste_globals,


### PR DESCRIPTION
In `print_globals`, there is a small typo. I changed "Fonctions" to "Functions"