### PR TITLE
Fix test roxygen2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 ^Meta$
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
+^CONTRIBUTING\.md$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to checkhelper
+
+This outlines how to propose a change to checkhelper.
+For a detailed discussion on contributing to this and other tidyverse packages, please see the [development contributing guide](https://rstd.io/tidy-contrib) and our [code review principles](https://code-review.tidyverse.org/).
+
+
+## All contribution welcomed
+
+We are open to any contribution, from typos to new features. We will guide you throughout the process and make you in a safe position to contribute, whatever is your level in R programming.
+
+## Package versions required to develop
+
+- `{roxygen2}`: Version > `7.1.2` is required.
+
+## Fixing typos
+
+You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the _source_ file. 
+This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file. 
+You can find the `.R` file that generates the `.Rd` by reading the comment in the first line.
+
+## Bigger changes
+
+If you want to make a bigger change, it's a good idea to first file an issue and make sure someone from the team agrees that it’s needed. 
+If you’ve found a bug, please file an issue that illustrates the bug with a minimal 
+[reprex](https://www.tidyverse.org/help/#reprex) (this will also help you write a unit test, if needed).
+See our guide on [how to create a great issue](https://code-review.tidyverse.org/issues/) for more advice.
+
+### Pull request process
+
+*   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("ThinkR-open/checkhelper", fork = TRUE)`.
+
+*   Install all development dependencies with `devtools::install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
+    If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing. 
+*   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.
+
+*   Make your changes, commit to git, and then create a PR by running `usethis::pr_push()`, and following the prompts in your browser.
+    The title of your PR should briefly describe the change.
+    The body of your PR should contain `Fixes #issue-number`.
+
+*  For user-facing changes, add a bullet to the top of `NEWS.md` (i.e. just below the first header). Follow the style described in <https://style.tidyverse.org/news.html>.
+
+### Code style
+
+*   New code should follow the tidyverse [style guide](https://style.tidyverse.org). 
+    You can use the [styler](https://CRAN.R-project.org/package=styler) package to apply these styles, but please don't restyle code that has nothing to do with your PR.  
+
+*  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html), for documentation.  
+
+*  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. 
+   Contributions with test cases included are easier to accept.  
+
+## Code of Conduct
+
+Please note that the checkhelper project is released with a
+[Contributor Code of Conduct](https://github.com/ThinkR-open/checkhelper/blob/main/CODE_OF_CONDUCT.md). By contributing to this
+project you agree to abide by its terms.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: checkhelper
 Title: Deal with Check Outputs
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: c(
     person("Sebastien", "Rochette", , "sebastien@thinkr.fr", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1565-9313")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # checkhelper (development)
 
+## Bug fixes 
+
+- Modification of unit tests following {roxygen2} changes. `find_missing_values` only return messages instead of warnings. (@MurielleDelmotte) 
+
 # checkhelper 0.1.0
 
 ## Major changes

--- a/dev/0-dev_history.Rmd
+++ b/dev/0-dev_history.Rmd
@@ -50,6 +50,9 @@ usethis::use_readme_rmd()
 usethis::use_code_of_conduct("codeofconduct@thinkr.fr")
 # NEWS
 usethis::use_news_md()
+# contributing
+usethis::use_tidy_contributing()
+usethis::use_build_ignore("CONTRIBUTING.md")
 ```
 
 **From now, you will need to "inflate" your package at least once to be able to use the following commands. Let's go to your flat template, and come back here later if/when needed.**

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,6 @@
+test_that("Package version required", {
+
+  # Check the version of the package roxygen2 to take into account the breaking change.
+  expect_true(packageVersion("roxygen2") > "7.1.2")
+
+})

--- a/tests/testthat/test-find_missing_values.R
+++ b/tests/testthat/test-find_missing_values.R
@@ -1,18 +1,29 @@
 path <- suppressWarnings(create_example_pkg())
 
 test_that("find_missing_tags works", {
-  if (packageVersion("roxygen2") > "7.1.2") {
+
+  # Check that the information transmitted by roxygen2 is correctly retransmitted by checkhelper
+
+  if (packageVersion("roxygen2") >= "7.3.0") {
+    # roxygen > 7.3.0 only generates messages
+    out <- expect_message(
+      find_missing_tags(path),
+      "my_long_fun_name_for_multiple_lines_globals"
+    )
+
+    expect_message(
+      find_missing_tags(path),
+      "@return"
+    )
+
+  } else {
+    # roxygen > 7.1.2 generates warnings and messages
     expect_warning(
       out <- expect_message(
         find_missing_tags(path),
         "my_long_fun_name_for_multiple_lines_globals"
       ),
       regexp = "@return"
-    )
-  } else {
-    out <- expect_message(
-      find_missing_tags(path),
-      "my_long_fun_name_for_multiple_lines_globals"
     )
   }
 
@@ -38,17 +49,10 @@ test_that("find_missing_tags works", {
   expect_equal(functions$has_export, c(TRUE, TRUE, FALSE, FALSE, TRUE))
   # last is true because of rdname tag
 
-  if (packageVersion("roxygen2") > "7.1.2") {
     expect_equal(
       functions$has_return,
       c(FALSE, TRUE, FALSE, FALSE, TRUE)
     )
-  } else {
-    expect_equal(
-      functions$has_return,
-      c(TRUE, TRUE, FALSE, FALSE, TRUE)
-    )
-  }
 
   expect_equal(
     functions$has_nord,
@@ -110,13 +114,35 @@ the_other_alias3 <- the_function",
       file = "R/function2.R"
     )
 
-    expect_warning(
-      attachment::att_amend_desc(),
-      regexp = "@return"
-    )
+    if (packageVersion("roxygen2") >= "7.3.0") {
+      # roxygen > 7.3.0 generates a message
+
+      expect_message(attachment::att_amend_desc(),
+                     regexp = "@return")
+    } else {
+      # roxygen > 7.1.2 generates a warning
+      expect_warning(attachment::att_amend_desc(),
+                     regexp = "@return")
+    }
+
   })
 
-  if (packageVersion("roxygen2") > "7.1.2") {
+  if (packageVersion("roxygen2") >= "7.3.0") {
+    # roxygen > 7.3.0 only generates messages
+
+    out <- expect_message(
+      find_missing_tags(path),
+      "my_long_fun_name_for_multiple_lines_globals"
+    )
+
+    expect_message(
+      find_missing_tags(path),
+      "@return"
+    )
+
+  } else {
+    # roxygen > 7.1.2 generates warnings and messages
+
     expect_warning(
       out <- expect_message(
         find_missing_tags(path),
@@ -124,11 +150,7 @@ the_other_alias3 <- the_function",
       ),
       regexp = "@return"
     )
-  } else {
-    out <- expect_message(
-      find_missing_tags(path),
-      "my_long_fun_name_for_multiple_lines_globals"
-    )
+
   }
 
   expect_type(out, "list")


### PR DESCRIPTION
fix: test with roxygen >=7.3.0

why:
- with roxygen2 v7.3.0, tests fail (find_missing_value))
- roxygen2 now returns a message instead of a warning

what:
- added a condition on the roxygen2 version to test a message or warning
- check a minimum version for roxygen2 (>7.1.2)
- removes testing on versions prior to 7.1.2

issue https://github.com/ThinkR-open/checkhelper/issues/86