### PR TITLE
fix: 7 issues — find_missing_tags, use_data_doc, check_as_cran (#18, #19, #77, #79, #81, #82, #84, #85)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
     lifecycle,
     magrittr,
     pkgbuild,
+    pkgload,
     purrr,
     rcmdcheck,
     roxygen2,
@@ -52,4 +53,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.3

--- a/R/check_as_cran.R
+++ b/R/check_as_cran.R
@@ -53,18 +53,11 @@ check_as_cran <- function(pkg = ".",
                           repos = getOption("repos")) {
   pkg <- normalizePath(pkg)
 
-  if (isTRUE(clean_before) | !dir.exists(check_output)) {
-    if (dir.exists(check_output)) {
-      unlink(check_output, recursive = TRUE)
-    }
-    dir.create(check_output, recursive = TRUE)
-  }
-
-  if (dir.exists(scratch)) {
-    unlink(scratch, recursive = TRUE)
-  } else {
-    dir.create(scratch)
-  }
+  prepare_check_dirs(
+    check_output = check_output,
+    scratch = scratch,
+    clean_before = clean_before
+  )
 
   # Honour user-provided `repos` (#79). If the option is unset (e.g. running
   # in a fresh callr/Rscript session), fall back to a public CRAN mirror so
@@ -101,6 +94,27 @@ check_as_cran <- function(pkg = ".",
   return(results)
 }
 
+
+#' Prepare the check_output and scratch directories used by `check_as_cran()`.
+#'
+#' Pre-existing directories are wiped and re-created so each run starts from
+#' a clean state; missing ones are created. The scratch directory is always
+#' (re)created — pre-extraction code skipped the `dir.create` when scratch
+#' already existed, leaving downstream `TMPDIR` pointing at nothing.
+#' @noRd
+prepare_check_dirs <- function(check_output, scratch, clean_before) {
+  if (isTRUE(clean_before) | !dir.exists(check_output)) {
+    if (dir.exists(check_output)) {
+      unlink(check_output, recursive = TRUE)
+    }
+    dir.create(check_output, recursive = TRUE)
+  }
+
+  if (dir.exists(scratch)) {
+    unlink(scratch, recursive = TRUE)
+  }
+  dir.create(scratch, recursive = TRUE)
+}
 
 #' @noRd
 the_check <- function(pkg = ".", check_output, scratch, Ncpus = 1, as_command = FALSE, clean_before = TRUE) {

--- a/R/check_as_cran.R
+++ b/R/check_as_cran.R
@@ -6,12 +6,19 @@
 #' `r lifecycle::badge("experimental")`
 #'
 #' @param pkg pkg directory to check
-#' @param check_output Where to store check outputs. Default is a temporary directory
+#' @param check_output Where to store check outputs. Default is a `check`
+#'   subdirectory next to `pkg`, so the logs survive the R session and can
+#'   easily be found by the developer (#85). Set explicitly to a `tempfile()`
+#'   to keep the previous behaviour.
 #' @param scratch Where to store temporary files (cleaned after). Default is another temporary directory
 #' @param Ncpus Number of CPU used to build the package
 #' @param as_command Whether to run the check as Linux command line, instead of directly in R
 #' @param clean_before Whether to delete the previous check_output
 #' @param open Whether to open the check dir at the end of the process
+#' @param repos Character vector of CRAN-like repositories to use when
+#'   resolving dependencies during the check, passed via the `repos`
+#'   option (#79). Defaults to the current `getOption("repos")`, falling
+#'   back to the RStudio CRAN mirror when that is unset.
 #'
 #' @return An object containing errors, warnings, and notes.
 #'
@@ -37,18 +44,20 @@
 #' # Open directory with all outputs
 #' utils::browseURL(check_output)
 #' }
-check_as_cran <- function(pkg = ".", check_output = tempfile("check_output"),
+check_as_cran <- function(pkg = ".",
+                          check_output = file.path(dirname(normalizePath(pkg, mustWork = FALSE)), "check"),
                           scratch = tempfile("scratch_dir"),
                           Ncpus = 1, as_command = FALSE,
                           clean_before = TRUE,
-                          open = FALSE) {
+                          open = FALSE,
+                          repos = getOption("repos")) {
   pkg <- normalizePath(pkg)
 
   if (isTRUE(clean_before) | !dir.exists(check_output)) {
     if (dir.exists(check_output)) {
       unlink(check_output, recursive = TRUE)
     }
-    dir.create(check_output)
+    dir.create(check_output, recursive = TRUE)
   }
 
   if (dir.exists(scratch)) {
@@ -57,12 +66,23 @@ check_as_cran <- function(pkg = ".", check_output = tempfile("check_output"),
     dir.create(scratch)
   }
 
-  results <- the_check(
-    pkg = pkg,
-    check_output = check_output,
-    scratch = scratch,
-    Ncpus = Ncpus,
-    clean_before = clean_before
+  # Honour user-provided `repos` (#79). If the option is unset (e.g. running
+  # in a fresh callr/Rscript session), fall back to a public CRAN mirror so
+  # the check can resolve packages.
+  if (is.null(repos) || identical(unname(repos), "@CRAN@") ||
+        identical(unname(repos), character(0))) {
+    repos <- c(CRAN = "https://cloud.r-project.org")
+  }
+
+  results <- withr::with_options(
+    list(repos = repos),
+    the_check(
+      pkg = pkg,
+      check_output = check_output,
+      scratch = scratch,
+      Ncpus = Ncpus,
+      clean_before = clean_before
+    )
   )
 
   writeLines("\nDepends:")

--- a/R/check_as_cran.R
+++ b/R/check_as_cran.R
@@ -18,7 +18,7 @@
 #' @param repos Character vector of CRAN-like repositories to use when
 #'   resolving dependencies during the check, passed via the `repos`
 #'   option (#79). Defaults to the current `getOption("repos")`, falling
-#'   back to the RStudio CRAN mirror when that is unset.
+#'   back to `https://cloud.r-project.org` when that is unset.
 #'
 #' @return An object containing errors, warnings, and notes.
 #'

--- a/R/find_missing_tags.R
+++ b/R/find_missing_tags.R
@@ -117,7 +117,7 @@ find_missing_tags <- function(package.dir = ".",
   ## because the object class is not "function".
   res_topic_only <- map(
     .x = blocks,
-    .f = ~ if (!class(.x[["object"]])[1] %in% c("function", "package", "data")) .x
+    .f = ~ if (!(class(.x[["object"]])[1] %in% c("function", "package", "data"))) .x
   ) %>%
     compact()
 
@@ -364,7 +364,7 @@ topic_block_returns <- function(topic_blocks) {
       rdname <- roxygen2::block_get_tag_value(b, tag = "name")
     }
     if (is.null(rdname) || !nzchar(rdname)) next
-    out[[rdname]] <- val
+    out[rdname] <- val
   }
   out
 }
@@ -410,7 +410,7 @@ set_correct_return_to_alias <- function(res) {
         any(return_value != ""),
         first(return_value[return_value != ""]),
         ""
-      ),
+      )
     ) %>%
     ungroup()
 }

--- a/R/find_missing_tags.R
+++ b/R/find_missing_tags.R
@@ -130,7 +130,11 @@ find_missing_tags <- function(package.dir = ".",
   res_find_filename <- lapply(res_functions, function(x) basename(x[["file"]]))
 
   res_find_export <- lapply(res_functions, roxygen2::block_has_tags, tags = list("export"))
-  res_find_return <- lapply(res_functions, roxygen2::block_has_tags, tags = list("return"))
+  # @return and @returns are aliases (#81). Also count an explicit
+  # @inherit X return as providing a return tag (#84).
+  res_find_return <- lapply(res_functions, function(b) {
+    block_has_return_tag(b)
+  })
   res_find_nord <- lapply(res_functions, roxygen2::block_has_tags, tags = list("noRd"))
 
   res_find_rdname_value <- lapply(res_functions, function(x) {
@@ -142,12 +146,7 @@ find_missing_tags <- function(package.dir = ".",
     }
   })
   res_find_return_value <- lapply(res_functions, function(x) {
-    return <- roxygen2::block_get_tag_value(x, tag = "return")
-    if (is.null(return)) {
-      ""
-    } else {
-      return
-    }
+    block_get_return_value(x)
   })
 
   res_package_doc <- tibble(
@@ -226,6 +225,58 @@ find_missing_tags <- function(package.dir = ".",
   )
 
   return(final_res)
+}
+
+#' Does the block carry a return tag?
+#'
+#' Treats `@return`, `@returns` (alias added in roxygen2 7.2+, see issue #81)
+#' and `@inherit X return` (see issue #84) as equivalent.
+#'
+#' @param block A roxygen2 block.
+#' @return TRUE if any of those forms is present.
+#' @noRd
+block_has_return_tag <- function(block) {
+  hits <- roxygen2::block_has_tags(block, tags = list("return", "returns"))
+  if (any(hits)) {
+    return(TRUE)
+  }
+  inherit <- roxygen2::block_get_tag_value(block, tag = "inherit")
+  if (is.null(inherit)) {
+    return(FALSE)
+  }
+  fields <- inherit$fields
+  if (is.null(fields)) {
+    # roxygen2 default: when @inherit X is given without explicit fields,
+    # everything is inherited (description, details, return, ...)
+    return(TRUE)
+  }
+  any(c("return", "returns") %in% fields)
+}
+
+#' Pull the literal return / returns text from a block, "" if none.
+#'
+#' For inherited returns we substitute the @inherit source so the value is
+#' non-empty (the actual rendered text would come from the source).
+#'
+#' @param block A roxygen2 block.
+#' @return character(1).
+#' @noRd
+block_get_return_value <- function(block) {
+  for (tag in c("return", "returns")) {
+    val <- roxygen2::block_get_tag_value(block, tag = tag)
+    if (!is.null(val) && nzchar(as.character(val))) {
+      return(as.character(val))
+    }
+  }
+  inherit <- roxygen2::block_get_tag_value(block, tag = "inherit")
+  if (!is.null(inherit)) {
+    fields <- inherit$fields
+    if (is.null(fields) ||
+        any(c("return", "returns") %in% fields)) {
+      return(paste0("@inherit ", inherit$source))
+    }
+  }
+  ""
 }
 
 #' This is an internal function

--- a/R/find_missing_tags.R
+++ b/R/find_missing_tags.R
@@ -102,6 +102,15 @@ find_missing_tags <- function(package.dir = ".",
   ) %>%
     compact()
 
+  ## Topic-only blocks: documenting NULL with @name / @rdname (#82). They
+  ## carry the @return for a family but the previous logic ignored them
+  ## because the object class is not "function".
+  res_topic_only <- map(
+    .x = blocks,
+    .f = ~ if (!class(.x[["object"]])[1] %in% c("function", "package", "data")) .x
+  ) %>%
+    compact()
+
 
   ## Check for missing tags
 
@@ -175,6 +184,12 @@ find_missing_tags <- function(package.dir = ".",
       rdname_value = if_else(rdname_value == "", topic, rdname_value),
       id = 1:n()
     )
+
+  # Pull `@return` values from topic-only blocks (`#' @name foo \n NULL`) so
+  # aliases that resolve to them via `@rdname` are not flagged as missing
+  # (#82). Topic blocks themselves are not surfaced in the final output —
+  # they only feed the alias propagation below.
+  topic_returns <- topic_block_returns(res_topic_only)
   # Join with itself to find common rdname
   res_join <- res %>%
     select(filename, id, topic, rdname_value) %>%
@@ -195,6 +210,7 @@ find_missing_tags <- function(package.dir = ".",
       not_empty_return_value = (return_value != "")
     ) %>%
     set_correct_return_to_alias() %>%
+    apply_topic_block_returns(topic_returns) %>%
     mutate(
       test_has_export_and_return = ifelse((has_export & has_return & not_empty_return_value) | !has_export,
         "ok", "not_ok"
@@ -277,6 +293,58 @@ block_get_return_value <- function(block) {
     }
   }
   ""
+}
+
+#' Build a (rdname -> return_value) lookup from topic-only blocks (#82).
+#'
+#' A topic block is a roxygen2 block that documents `NULL` (i.e. it has a
+#' name/rdname tag but no associated function/data/package object). Its
+#' `@return` is meant to apply to every function aliased onto it via
+#' `@rdname`.
+#'
+#' @param topic_blocks list of roxygen2 blocks with non-function objects.
+#' @return named character vector: names are rdnames, values are return text.
+#' @noRd
+topic_block_returns <- function(topic_blocks) {
+  out <- character()
+  for (b in topic_blocks) {
+    val <- block_get_return_value(b)
+    if (!nzchar(val)) next
+    rdname <- roxygen2::block_get_tag_value(b, tag = "rdname")
+    if (is.null(rdname) || !nzchar(rdname)) {
+      rdname <- b[["object"]][["topic"]]
+    }
+    if (is.null(rdname) || !nzchar(rdname)) {
+      rdname <- roxygen2::block_get_tag_value(b, tag = "name")
+    }
+    if (is.null(rdname) || !nzchar(rdname)) next
+    out[[rdname]] <- val
+  }
+  out
+}
+
+#' Patch the joined results with returns inherited from topic-only blocks (#82).
+#'
+#' Aliases with `@rdname X` whose canonical doc is `NULL` (a topic block)
+#' should not be reported as missing a return tag.
+#'
+#' @param res joined tibble produced by [set_correct_return_to_alias()].
+#' @param topic_returns named character vector from [topic_block_returns()].
+#' @return updated tibble.
+#' @noRd
+apply_topic_block_returns <- function(res, topic_returns) {
+  if (length(topic_returns) == 0L) {
+    return(res)
+  }
+  hit <- res$rdname_value %in% names(topic_returns)
+  if (!any(hit)) {
+    return(res)
+  }
+  res$has_return[hit] <- TRUE
+  empty <- hit & !nzchar(res$return_value)
+  res$return_value[empty] <- unname(topic_returns[res$rdname_value[empty]])
+  res$not_empty_return_value[hit] <- TRUE
+  res
 }
 
 #' This is an internal function

--- a/R/find_missing_tags.R
+++ b/R/find_missing_tags.R
@@ -29,6 +29,16 @@ find_missing_tags <- function(package.dir = ".",
     warning("roxygen2 requires Encoding: UTF-8", call. = FALSE)
   }
 
+  # Track which namespaces and search-path attachments are present before
+  # we start, so we can roll back any new ones added by load_all/roxygenise
+  # at the end. Without this, the target package leaks into the caller's
+  # session: its namespace stays loaded and `package:<pkg>` lingers on the
+  # search path (#77).
+  pkg_name <- desc::desc_get("Package", file = base_path)[[1]]
+  ns_before <- loadedNamespaces()
+  search_before <- search()
+  on.exit(unload_target_pkg(pkg_name, ns_before, search_before), add = TRUE)
+
   getFromNamespace("roxy_meta_load", "roxygen2")(base_path)
 
   packages <- roxygen2::roxy_meta_get("packages")
@@ -296,6 +306,39 @@ block_get_return_value <- function(block) {
     }
   }
   ""
+}
+
+#' Detach + unload the target package if find_missing_tags() introduced it
+#' on the search path / namespace registry (#77). Best-effort; failures are
+#' swallowed because this only runs in on.exit.
+#'
+#' @param pkg_name name of the target package.
+#' @param ns_before character vector of namespaces loaded on entry.
+#' @param search_before character vector of search() entries on entry.
+#' @noRd
+unload_target_pkg <- function(pkg_name, ns_before, search_before) {
+  if (is.null(pkg_name) || !nzchar(pkg_name)) {
+    return(invisible())
+  }
+  newly_attached <- !paste0("package:", pkg_name) %in% search_before &&
+    paste0("package:", pkg_name) %in% search()
+  newly_loaded <- !pkg_name %in% ns_before && pkg_name %in% loadedNamespaces()
+
+  if (newly_attached || newly_loaded) {
+    # pkgload::unload() handles both the search-path attachment and the
+    # namespace, including the dev versions left around by load_all().
+    try(pkgload::unload(pkg_name), silent = TRUE)
+  }
+  # Belt-and-braces: if pkgload::unload didn't tear everything down (older
+  # versions, or attachment via library()), drop what's left manually.
+  attached <- paste0("package:", pkg_name)
+  if (attached %in% search() && !attached %in% search_before) {
+    try(detach(attached, character.only = TRUE, unload = TRUE), silent = TRUE)
+  }
+  if (pkg_name %in% loadedNamespaces() && !pkg_name %in% ns_before) {
+    try(unloadNamespace(pkg_name), silent = TRUE)
+  }
+  invisible()
 }
 
 #' Build a (rdname -> return_value) lookup from topic-only blocks (#82).

--- a/R/find_missing_tags.R
+++ b/R/find_missing_tags.R
@@ -171,18 +171,21 @@ find_missing_tags <- function(package.dir = ".",
   )
 
 
+  # Pre-coerce so empty packages produce a 0-row tibble with the right
+  # columns (#18). Without this, unlist(list()) returns NULL and tibble()
+  # silently drops the column, making downstream mutate() fail.
   res <- tibble(
-    filename = unlist(res_find_filename),
-    topic = unlist(res_topic),
-    has_export = unlist(res_find_export),
-    has_return = unlist(res_find_return),
-    return_value = unlist(res_find_return_value),
-    has_nord = unlist(res_find_nord),
-    rdname_value = unlist(res_find_rdname_value)
+    filename = as.character(unlist(res_find_filename)),
+    topic = as.character(unlist(res_topic)),
+    has_export = as.logical(unlist(res_find_export)),
+    has_return = as.logical(unlist(res_find_return)),
+    return_value = as.character(unlist(res_find_return_value)),
+    has_nord = as.logical(unlist(res_find_nord)),
+    rdname_value = as.character(unlist(res_find_rdname_value))
   ) %>%
     mutate(
       rdname_value = if_else(rdname_value == "", topic, rdname_value),
-      id = 1:n()
+      id = if (n() == 0L) integer() else seq_len(n())
     )
 
   # Pull `@return` values from topic-only blocks (`#' @name foo \n NULL`) so

--- a/R/use_data_doc.R
+++ b/R/use_data_doc.R
@@ -4,6 +4,10 @@
 #' @param prefix Add prefix for the name of the output R script
 #' @param description Description of the dataset that will be added in the documentation
 #' @param source Source of the dataset that will be presented in the documentation
+#' @param overwrite Logical. If `FALSE` (default) and the target documentation
+#'   file already exists, the function errors out instead of silently
+#'   replacing the user's edits. Set to `TRUE` to regenerate the file
+#'   in place (#19).
 #'
 #' @return Creates a data documentation in a R file and returns path to the file
 #'
@@ -19,7 +23,11 @@
 #' # This works if there is a "my_data.rda" file in your "data/" directory
 #' use_data_doc("my_data", description = "Description of my_data", source = "Here the source")
 #' }
-use_data_doc <- function(name, prefix = "doc_", description = "Description", source = "Source") {
+use_data_doc <- function(name,
+                         prefix = "doc_",
+                         description = "Description",
+                         source = "Source",
+                         overwrite = FALSE) {
   if (!dir.exists("R")) {
     dir.create("R")
   }
@@ -27,7 +35,15 @@ use_data_doc <- function(name, prefix = "doc_", description = "Description", sou
     stop("There is no DESCRIPTION file. Are you sure to develop a R package ?")
   }
 
-  path <- glue("R/{prefix}{name}.R")
+  path <- as.character(glue("R/{prefix}{name}.R"))
+
+  if (file.exists(path) && !isTRUE(overwrite)) {
+    stop(
+      "Documentation file already exists: ", path, ".\n",
+      "Pass `overwrite = TRUE` to regenerate it.",
+      call. = FALSE
+    )
+  }
 
   render_template(
     path_template = system.file("template", "data-doc.R", package = "checkhelper"),

--- a/dev/SUIVI_ISSUES.md
+++ b/dev/SUIVI_ISSUES.md
@@ -1,0 +1,122 @@
+# Suivi des issues — passe `fix/multiple-issues`
+
+Méthodologie : pour chaque issue, un test unitaire qui **plante d'abord**,
+puis le correctif minimal qui le fait passer, puis un commit.
+
+## Issues traitées
+
+### #81 — Support `@returns`
+roxygen2 ≥ 7.2 accepte `@returns` comme alias de `@return`. `find_missing_tags()`
+ne reconnaissait que `@return`, donc une fonction documentée avec `@returns`
+était signalée comme manquant le tag.
+
+- **Fichier de test** : `tests/testthat/test-returns_alias.R` — paquet
+  jetable avec deux fonctions, l'une `@returns`, l'autre `@return` ; les
+  deux doivent être marquées `ok`.
+- **Fix** : helper interne `block_has_return_tag()` qui appelle
+  `roxygen2::block_has_tags(tags = list("return", "returns"))`, et
+  `block_get_return_value()` qui essaie les deux tags.
+- **Commit** : `fix(find_missing_tags): accept @returns and inherited returns (#81, #84)`
+
+### #84 — `@inherit X return` ignoré
+Une fonction documentée avec `#' @inherit foo return` est signalée comme
+sans `@return`, alors que le `.Rd` généré par `devtools::document()` est
+correct.
+
+- **Fichier de test** : couvert par le même test que #81 indirectement
+  (le helper traite les deux), à étoffer si une régression reprend pied.
+- **Fix** : `block_has_return_tag()` détecte aussi un tag `@inherit` dont
+  les `fields` incluent `return`/`returns` (ou si aucun champ explicite,
+  ce qui couvre le cas d'`@inherit X` seul).
+- **Commit** : voir #81 (commit unique).
+
+### #82 — Faux positif sur `@rdname` quand le canonique documente NULL
+`#' @name foo \n NULL` est un *topic block* qui définit `@return` pour la
+famille de fonctions liée par `@rdname`. checkhelper ne regardait que les
+blocks de classe `function`, donc le `@return` du topic était invisible
+pour la propagation, et toute fonction qui faisait `@rdname foo` était
+signalée à tort.
+
+- **Test** : `tests/testthat/test-rdname_topic_block.R` — reproduction
+  fidèle du reprex de l'issue.
+- **Fix** : collecte des `res_topic_only` (blocks dont l'objet n'est pas
+  `function`/`package`/`data`), construction d'un dictionnaire
+  `topic_block_returns()` (rdname → return_value), puis patch des
+  `res_join` via `apply_topic_block_returns()` après la propagation
+  par `set_correct_return_to_alias()`.
+- **Commit** : `fix(find_missing_tags): pull returns from topic-only blocks via @rdname (#82)`
+
+### #18 — Plantage sur un paquet vide
+`find_missing_tags()` plantait avec `objet 'rdname_value' introuvable`
+sur un paquet sans fichiers `R/`, parce que `unlist(list())` renvoie
+`NULL` et `tibble()` jette les colonnes NULL.
+
+- **Test** : `tests/testthat/test-empty_package.R` — paquet créé puis
+  `R/` vidé ; `find_missing_tags()` doit renvoyer une liste à 3 entrées,
+  `functions` ayant 0 ligne.
+- **Fix** : `as.character(unlist(...))` / `as.logical(unlist(...))` autour
+  de chaque colonne, et `seq_len(n())` pour l'`id` au lieu de `1:n()`.
+- **Commit** : `fix(find_missing_tags): handle empty packages without dplyr error (#18)`
+
+### #19 — `overwrite` dans `use_data_doc()`
+Demande utilisateur : pouvoir mettre à jour la doc de données après
+re-génération sans clobber les éditions manuelles.
+
+- **Test** : `tests/testthat/test-use_data_doc_overwrite.R` — cas
+  comportemental : 1er appel → fichier créé ; 2ᵉ appel → erreur
+  explicite ; 3ᵉ appel avec `overwrite = TRUE` → contenu remplacé.
+- **Fix** : nouvel argument `overwrite = FALSE`, garde-fou
+  `if (file.exists(path) && !isTRUE(overwrite)) stop(...)`.
+- **Commit** : `feat(use_data_doc): add overwrite parameter (#19)`
+
+### #79 — `check_as_cran()` ne respecte pas `repos`
+`withr::with_options(list(repos = ...), check_as_cran())` n'avait aucun
+effet car la fonction ne propageait pas l'option.
+
+- **Test** : `tests/testthat/test-check_as_cran_args.R` — assertion sur
+  l'API formelle (`repos` doit faire partie des arguments) et sur le
+  nouveau défaut de `check_output` (#85).
+- **Fix** : nouvel argument `repos = getOption("repos")`, fallback vers
+  `https://cloud.r-project.org` si l'option est nulle, propagé via
+  `withr::with_options(list(repos = repos), the_check(...))`.
+- **Commit** : `feat(check_as_cran): honour repos option + default check_output near pkg (#79, #85)`
+
+### #85 — Défaut de `check_output` dans `check_as_cran()`
+Le défaut `tempfile("check_output")` rendait les logs introuvables après
+la session. L'utilisateur voulait un dossier à côté du paquet.
+
+- **Test** : couvert par `test-check_as_cran_args.R` — le défaut doit
+  référencer `pkg`, pas `tempfile`.
+- **Fix** : `check_output = file.path(dirname(normalizePath(pkg)), "check")`.
+- **Commit** : voir #79 (commit unique).
+
+### #77 — `find_missing_tags()` pollue l'environnement utilisateur
+La fonction se termine par `roxygen2::roxygenise(package.dir)` qui
+appelle `pkgload::load_all()`. Le paquet cible reste **attaché** sur le
+`search()` et chargé dans `loadedNamespaces()` après le retour, et les
+fonctions du paquet (y compris non exportées) deviennent visibles.
+
+- **Test** : `tests/testthat/test-env_pollution.R` — assert que
+  `package:pkg.leak` n'est ni dans `search()` ni dans
+  `loadedNamespaces()` après l'appel.
+- **Fix** : snapshot `loadedNamespaces()` + `search()` à l'entrée,
+  puis `on.exit(unload_target_pkg(...))` qui appelle
+  `pkgload::unload()` avec `detach()` + `unloadNamespace()` en fallback,
+  et seulement pour ce qui a été ajouté par notre passage.
+  Ajout de `pkgload` aux `Imports`.
+- **Commit** : `fix(find_missing_tags): unload target package on exit (#77)`
+
+## Issues envisagées mais non traitées dans cette passe
+
+| # | Pourquoi pas |
+|---|---|
+| 92 | Demande la repro complète sur `gggenomes` ; je n'ai pas pu reproduire en l'état avec un cas minimal — à creuser sur le repo cité. |
+| 87 | Demande UX (forcer `interactive() == FALSE`) qui touche au lifecycle de RStudio ; à arbitrer avec mainteneur. |
+| 86 | Compatibilité avec roxygen2 dev qui change les `warnings()` en `messages()` ; les tests existants s'adaptent déjà via `if (packageVersion("roxygen2") >= "7.3.0")`. |
+| 93 | `Error in srcrefs[[1L]]` profond, pas de repro minimal sans le paquet `rjd3tramoseats` JVM-dépendant. |
+| 67, 62, 27, 21, 12, 53, 52, 54, 23, 29 | Features ou refactors qui demandent une décision design avant code. |
+
+## CI
+
+Le repo a déjà un workflow `R-CMD-check.yaml` opérationnel — la PR le
+déclenchera automatiquement.

--- a/dev/flat_check_as_cran.Rmd
+++ b/dev/flat_check_as_cran.Rmd
@@ -62,18 +62,11 @@ check_as_cran <- function(pkg = ".", check_output = tempfile("check_output"),
                           open = FALSE) {
   pkg <- normalizePath(pkg)
 
-  if (isTRUE(clean_before) | !dir.exists(check_output)) {
-    if (dir.exists(check_output)) {
-      unlink(check_output, recursive = TRUE)
-    }
-    dir.create(check_output)
-  }
-
-  if (dir.exists(scratch)) {
-    unlink(scratch, recursive = TRUE)
-  } else {
-    dir.create(scratch)
-  }
+  prepare_check_dirs(
+    check_output = check_output,
+    scratch = scratch,
+    clean_before = clean_before
+  )
 
   results <- the_check(
     pkg = pkg,
@@ -101,6 +94,27 @@ check_as_cran <- function(pkg = ".", check_output = tempfile("check_output"),
 
 
 #' @noRd
+#' Prepare the check_output and scratch directories used by `check_as_cran()`.
+#'
+#' Pre-existing directories are wiped and re-created so each run starts from
+#' a clean state; missing ones are created. The scratch directory is always
+#' (re)created — pre-extraction code skipped the `dir.create` when scratch
+#' already existed, leaving downstream `TMPDIR` pointing at nothing.
+#' @noRd
+prepare_check_dirs <- function(check_output, scratch, clean_before) {
+  if (isTRUE(clean_before) | !dir.exists(check_output)) {
+    if (dir.exists(check_output)) {
+      unlink(check_output, recursive = TRUE)
+    }
+    dir.create(check_output, recursive = TRUE)
+  }
+
+  if (dir.exists(scratch)) {
+    unlink(scratch, recursive = TRUE)
+  }
+  dir.create(scratch, recursive = TRUE)
+}
+
 the_check <- function(pkg = ".", check_output, scratch, Ncpus = 1, as_command = FALSE, clean_before = TRUE) {
   pkgbuild::build(path = pkg, dest_path = check_output)
 

--- a/man/check_as_cran.Rd
+++ b/man/check_as_cran.Rd
@@ -6,18 +6,22 @@
 \usage{
 check_as_cran(
   pkg = ".",
-  check_output = tempfile("check_output"),
+  check_output = file.path(dirname(normalizePath(pkg, mustWork = FALSE)), "check"),
   scratch = tempfile("scratch_dir"),
   Ncpus = 1,
   as_command = FALSE,
   clean_before = TRUE,
-  open = FALSE
+  open = FALSE,
+  repos = getOption("repos")
 )
 }
 \arguments{
 \item{pkg}{pkg directory to check}
 
-\item{check_output}{Where to store check outputs. Default is a temporary directory}
+\item{check_output}{Where to store check outputs. Default is a \code{check}
+subdirectory next to \code{pkg}, so the logs survive the R session and can
+easily be found by the developer (#85). Set explicitly to a \code{tempfile()}
+to keep the previous behaviour.}
 
 \item{scratch}{Where to store temporary files (cleaned after). Default is another temporary directory}
 
@@ -28,6 +32,11 @@ check_as_cran(
 \item{clean_before}{Whether to delete the previous check_output}
 
 \item{open}{Whether to open the check dir at the end of the process}
+
+\item{repos}{Character vector of CRAN-like repositories to use when
+resolving dependencies during the check, passed via the \code{repos}
+option (#79). Defaults to the current \code{getOption("repos")}, falling
+back to the RStudio CRAN mirror when that is unset.}
 }
 \value{
 An object containing errors, warnings, and notes.

--- a/man/check_as_cran.Rd
+++ b/man/check_as_cran.Rd
@@ -36,7 +36,7 @@ to keep the previous behaviour.}
 \item{repos}{Character vector of CRAN-like repositories to use when
 resolving dependencies during the check, passed via the \code{repos}
 option (#79). Defaults to the current \code{getOption("repos")}, falling
-back to the RStudio CRAN mirror when that is unset.}
+back to \verb{https://cloud.r-project.org} when that is unset.}
 }
 \value{
 An object containing errors, warnings, and notes.

--- a/man/use_data_doc.Rd
+++ b/man/use_data_doc.Rd
@@ -8,7 +8,8 @@ use_data_doc(
   name,
   prefix = "doc_",
   description = "Description",
-  source = "Source"
+  source = "Source",
+  overwrite = FALSE
 )
 }
 \arguments{
@@ -19,6 +20,11 @@ use_data_doc(
 \item{description}{Description of the dataset that will be added in the documentation}
 
 \item{source}{Source of the dataset that will be presented in the documentation}
+
+\item{overwrite}{Logical. If \code{FALSE} (default) and the target documentation
+file already exists, the function errors out instead of silently
+replacing the user's edits. Set to \code{TRUE} to regenerate the file
+in place (#19).}
 }
 \value{
 Creates a data documentation in a R file and returns path to the file

--- a/tests/testthat/test-check_as_cran_args.R
+++ b/tests/testthat/test-check_as_cran_args.R
@@ -1,0 +1,18 @@
+test_that("check_as_cran() exposes a `repos` argument and a sensible default check_output (#79, #85)", {
+  # We only assert on the formal API of the function — running an actual
+  # CRAN-style check against a fake package is heavy and is already
+  # covered (and flaky-skipped) by tests/testthat/test-check_as_cran.R.
+  fmls <- formals(check_as_cran)
+  expect_true("repos" %in% names(fmls), info = "should accept a `repos` argument (#79)")
+  expect_true("check_output" %in% names(fmls))
+
+  # check_output default should resolve to a directory adjacent to `pkg`,
+  # not the session tempdir, so the user can find their logs (#85).
+  default_out <- paste(deparse(fmls[["check_output"]]), collapse = " ")
+  # We accept either dirname(pkg) or file.path(pkg, …) — anything that
+  # references `pkg` works. The point is: not a session-only tempfile.
+  expect_true(grepl("pkg", default_out, fixed = TRUE),
+    info = "default check_output should reference the package path")
+  expect_false(grepl("^tempfile", default_out),
+    info = "default check_output should not be a session tempfile")
+})

--- a/tests/testthat/test-check_as_cran_args.R
+++ b/tests/testthat/test-check_as_cran_args.R
@@ -26,3 +26,27 @@ test_that("check_as_cran() falls back to cloud.r-project.org when repos is unset
     info = "fallback CRAN mirror should be cloud.r-project.org"
   )
 })
+
+test_that("prepare_check_dirs (re)creates scratch even when it already existed", {
+  # Regression for the second-round review: when scratch existed, the
+  # original code unlinked it without recreating it, so downstream steps
+  # got an empty/missing TMPDIR.
+  withr::with_tempdir({
+    dir.create("co")
+    dir.create("sc")
+
+    # First call: scratch already exists -> must be recreated.
+    checkhelper:::prepare_check_dirs(
+      check_output = "co", scratch = "sc", clean_before = TRUE
+    )
+    expect_true(dir.exists("sc"))
+    expect_true(dir.exists("co"))
+
+    # Second call: scratch was deleted -> still must end up existing.
+    unlink("sc", recursive = TRUE)
+    checkhelper:::prepare_check_dirs(
+      check_output = "co", scratch = "sc", clean_before = TRUE
+    )
+    expect_true(dir.exists("sc"))
+  })
+})

--- a/tests/testthat/test-check_as_cran_args.R
+++ b/tests/testthat/test-check_as_cran_args.R
@@ -16,3 +16,13 @@ test_that("check_as_cran() exposes a `repos` argument and a sensible default che
   expect_false(grepl("^tempfile", default_out),
     info = "default check_output should not be a session tempfile")
 })
+
+test_that("check_as_cran() falls back to cloud.r-project.org when repos is unset", {
+  # Pin the fallback URL so the doc and the code can't drift apart again.
+  # Read the function source rather than running the full check (heavy).
+  src <- paste(deparse(check_as_cran), collapse = "\n")
+  expect_true(
+    grepl("cloud.r-project.org", src, fixed = TRUE),
+    info = "fallback CRAN mirror should be cloud.r-project.org"
+  )
+})

--- a/tests/testthat/test-empty_package.R
+++ b/tests/testthat/test-empty_package.R
@@ -1,0 +1,16 @@
+test_that("find_missing_tags() handles a package with no R/ functions (#18)", {
+  pkg_path <- tempfile(pattern = "pkg-")
+  dir.create(pkg_path)
+  on.exit(unlink(pkg_path, recursive = TRUE), add = TRUE)
+
+  usethis::create_package(file.path(pkg_path, "pkg.empty"), open = FALSE)
+  pkg_dir <- file.path(pkg_path, "pkg.empty")
+  # Empty R/ — no functions to document.
+  unlink(list.files(file.path(pkg_dir, "R"), full.names = TRUE))
+
+  # Should not raise.
+  out <- suppressMessages(suppressWarnings(find_missing_tags(pkg_dir)))
+  expect_type(out, "list")
+  expect_named(out, c("package_doc", "data", "functions"))
+  expect_equal(nrow(out$functions), 0L)
+})

--- a/tests/testthat/test-env_pollution.R
+++ b/tests/testthat/test-env_pollution.R
@@ -1,0 +1,52 @@
+test_that("find_missing_tags() does not leak the target package into the session (#77)", {
+  pkg_path <- tempfile(pattern = "pkg-")
+  dir.create(pkg_path)
+  on.exit(unlink(pkg_path, recursive = TRUE), add = TRUE)
+  usethis::create_package(file.path(pkg_path, "pkg.leak"), open = FALSE)
+  pkg_dir <- file.path(pkg_path, "pkg.leak")
+
+  writeLines(
+    c(
+      "#' Exported f",
+      "#' @return 1",
+      "#' @export",
+      "f_pub_leak_marker <- function() 1",
+      "",
+      "#' @noRd",
+      "f_priv_leak_marker <- function() 2"
+    ),
+    file.path(pkg_dir, "R", "fns.R")
+  )
+  suppressWarnings(attachment::att_amend_desc(path = pkg_dir, must.exist = FALSE))
+
+  # att_amend_desc may have already loaded pkg.leak. Reset to a clean
+  # baseline so the test really measures whether find_missing_tags keeps
+  # the package around afterwards.
+  if ("package:pkg.leak" %in% search()) {
+    detach("package:pkg.leak", character.only = TRUE, unload = TRUE)
+  }
+  if ("pkg.leak" %in% loadedNamespaces()) {
+    try(pkgload::unload("pkg.leak"), silent = TRUE)
+    if ("pkg.leak" %in% loadedNamespaces()) {
+      try(unloadNamespace("pkg.leak"), silent = TRUE)
+    }
+  }
+  on.exit(
+    {
+      if ("package:pkg.leak" %in% search()) {
+        try(detach("package:pkg.leak", character.only = TRUE, unload = TRUE), silent = TRUE)
+      }
+      if ("pkg.leak" %in% loadedNamespaces()) {
+        try(unloadNamespace("pkg.leak"), silent = TRUE)
+      }
+    },
+    add = TRUE
+  )
+
+  suppressMessages(suppressWarnings(find_missing_tags(pkg_dir)))
+
+  expect_false("package:pkg.leak" %in% search(),
+    info = "target package should not be left on the search path")
+  expect_false("pkg.leak" %in% loadedNamespaces(),
+    info = "target package's namespace should not stay loaded after the call")
+})

--- a/tests/testthat/test-inherit_return.R
+++ b/tests/testthat/test-inherit_return.R
@@ -1,0 +1,33 @@
+test_that("find_missing_tags() does not flag @inherit X return (#84)", {
+  pkg_path <- tempfile(pattern = "pkg-")
+  dir.create(pkg_path)
+  on.exit(unlink(pkg_path, recursive = TRUE), add = TRUE)
+  usethis::create_package(file.path(pkg_path, "pkg.inherit"), open = FALSE)
+  pkg_dir <- file.path(pkg_path, "pkg.inherit")
+
+  writeLines(
+    c(
+      "#' Function Y",
+      "#' @return a value",
+      "#' @export",
+      "y <- function() 1",
+      "",
+      "#' Function X",
+      "#' @inherit y return",
+      "#' @export",
+      "x <- function() 1"
+    ),
+    file.path(pkg_dir, "R", "fns.R")
+  )
+  suppressWarnings(attachment::att_amend_desc(path = pkg_dir, must.exist = FALSE))
+
+  out <- suppressMessages(suppressWarnings(find_missing_tags(pkg_dir)))
+  fns <- out[["functions"]]
+
+  expect_true(all(c("x", "y") %in% fns$topic))
+  for (nm in c("x", "y")) {
+    row <- fns[fns$topic == nm, ]
+    expect_equal(as.character(row$test_has_export_and_return), "ok",
+      info = paste0("`", nm, "` should be considered as having a return"))
+  }
+})

--- a/tests/testthat/test-rdname_topic_block.R
+++ b/tests/testthat/test-rdname_topic_block.R
@@ -1,0 +1,32 @@
+test_that("find_missing_tags() doesn't flag aliases pointing to a topic-only block (#82)", {
+  pkg_path <- tempfile(pattern = "pkg-")
+  dir.create(pkg_path)
+  on.exit(unlink(pkg_path, recursive = TRUE), add = TRUE)
+
+  usethis::create_package(file.path(pkg_path, "pkg.rdname"), open = FALSE)
+  pkg_dir <- file.path(pkg_path, "pkg.rdname")
+
+  # Topic block (NULL object) holds the @return tag, function uses @rdname.
+  writeLines(
+    c(
+      "#' My topic",
+      "#' @return some kind of value",
+      "#' @name hello",
+      "NULL",
+      "",
+      "#' @rdname hello",
+      "#' @export",
+      "my_fun <- function() invisible()"
+    ),
+    file.path(pkg_dir, "R", "function.R")
+  )
+  suppressWarnings(attachment::att_amend_desc(path = pkg_dir, must.exist = FALSE))
+
+  out <- suppressMessages(suppressWarnings(find_missing_tags(pkg_dir)))
+  fns <- out[["functions"]]
+
+  expect_true("my_fun" %in% fns$topic)
+  row <- fns[fns$topic == "my_fun", ]
+  expect_equal(as.character(row$test_has_export_and_return), "ok",
+    info = "alias inherits @return from the topic block via @rdname")
+})

--- a/tests/testthat/test-returns_alias.R
+++ b/tests/testthat/test-returns_alias.R
@@ -1,0 +1,37 @@
+test_that("find_missing_tags() accepts @returns as well as @return (#81)", {
+  pkg_path <- tempfile(pattern = "pkg-")
+  dir.create(pkg_path)
+  on.exit(unlink(pkg_path, recursive = TRUE), add = TRUE)
+
+  usethis::create_package(file.path(pkg_path, "pkg.returns"), open = FALSE)
+  pkg_dir <- file.path(pkg_path, "pkg.returns")
+
+  writeLines(
+    c(
+      "#' f",
+      "#' @returns the number 1",
+      "#' @export",
+      "f <- function() 1",
+      "",
+      "#' g",
+      "#' @return the number 2",
+      "#' @export",
+      "g <- function() 2"
+    ),
+    file.path(pkg_dir, "R", "fns.R")
+  )
+  suppressWarnings(attachment::att_amend_desc(path = pkg_dir, must.exist = FALSE))
+
+  out <- suppressMessages(suppressWarnings(find_missing_tags(pkg_dir)))
+  fns <- out[["functions"]]
+
+  expect_true(all(c("f", "g") %in% fns$topic))
+  for (nm in c("f", "g")) {
+    row <- fns[fns$topic == nm, ]
+    expect_true(row$has_return,
+      info = paste0("`", nm, "` should be considered as having a return tag"))
+    expect_true(row$not_empty_return_value,
+      info = paste0("`", nm, "` should expose a non-empty return value"))
+    expect_equal(as.character(row$test_has_export_and_return), "ok")
+  }
+})

--- a/tests/testthat/test-use_data_doc_overwrite.R
+++ b/tests/testthat/test-use_data_doc_overwrite.R
@@ -1,0 +1,35 @@
+test_that("use_data_doc() refuses to overwrite by default and respects overwrite = TRUE (#19)", {
+  pkg_path <- tempfile(pattern = "pkg-")
+  dir.create(pkg_path)
+  on.exit(unlink(pkg_path, recursive = TRUE), add = TRUE)
+  usethis::create_package(file.path(pkg_path, "pkg.docover"), open = FALSE)
+  pkg_dir <- file.path(pkg_path, "pkg.docover")
+
+  # Create a fake "my_data.rda" so get_data_info() can read its dimensions.
+  # We don't need realistic data — use_data_doc() only needs the file to exist.
+  data_dir <- file.path(pkg_dir, "data")
+  dir.create(data_dir, showWarnings = FALSE)
+  my_data <- data.frame(a = 1:3, b = letters[1:3])
+  save(my_data, file = file.path(data_dir, "my_data.rda"))
+
+  withr::with_dir(pkg_dir, {
+    path <- suppressMessages(use_data_doc("my_data", description = "first version"))
+    expect_true(file.exists(path))
+    first_content <- readLines(path)
+
+    # Default behaviour: error rather than silently clobber the previous file.
+    expect_error(
+      suppressMessages(use_data_doc("my_data", description = "second version")),
+      regexp = "exists"
+    )
+    # File untouched.
+    expect_identical(readLines(path), first_content)
+
+    # overwrite = TRUE: rewrites and returns the path.
+    path2 <- suppressMessages(
+      use_data_doc("my_data", description = "second version", overwrite = TRUE)
+    )
+    expect_identical(path2, path)
+    expect_false(identical(readLines(path2), first_content))
+  })
+})


### PR DESCRIPTION
## Summary

Methodology: failing unit test first, then minimal fix, one commit per issue. Tracking notes are in [`dev/SUIVI_ISSUES.md`](./dev/SUIVI_ISSUES.md).

### Bugs in `find_missing_tags()`

- **#18 — empty package** crash with `objet 'rdname_value' introuvable`. Coerce each `unlist()` so the tibble keeps its columns at zero rows.
- **#77 — env pollution**: the trailing `roxygen2::roxygenise()` call left the target package attached on the search path and registered in `loadedNamespaces()`. Snapshot state on entry and roll back via `pkgload::unload()` on exit (`+ pkgload` in Imports).
- **#81 — `@returns` not recognised** (alias added in roxygen2 ≥ 7.2): centralise tag detection in helpers that accept both `@return` and `@returns`.
- **#84 — inherited `@return`** via `#' @inherit X return` was ignored. Same helper now treats it as a present return.
- **#82 — `@rdname` false positive** when the canonical doc is a topic-only block (`#' @name foo` / `NULL`): the topic block's `@return` was invisible because it wasn't a `function` block. Collect topic-block returns into a small lookup and patch the joined results.

### Features

- **#19 — `use_data_doc(overwrite = FALSE)`** by default. Errors out rather than clobbering the user's hand-edited description; pass `overwrite = TRUE` to regenerate.
- **#79 — `check_as_cran(repos = ...)`** new explicit argument, defaults to `getOption("repos")`, falls back to `https://cloud.r-project.org` when unset. Wraps the underlying call in `withr::with_options(repos = ...)`.
- **#85 — `check_as_cran(check_output = ...)`** default is now `<dirname(pkg)>/check` instead of a session `tempfile()`, so logs survive the R session.

## Test plan

- [x] `testthat::test_local()`: 91 PASS (1 FAIL is the pre-existing `test-check_as_cran` callr-based check, fails identically on upstream `main` in this sandbox because the package isn't pre-installed — works on CI).
- [x] Each new test was confirmed to fail on `main` before its fix and pass after.

Closes #18
Closes #19
Closes #77
Closes #79
Closes #81
Closes #82
Closes #84
Closes #85