### PR TITLE
feat(asciify): emit a one-line summary message in asciify_pkg()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# checkhelper (development version)
+
+## Minor changes
+
+- `asciify_pkg()` now emits a one-line summary message
+  (`"N file(s) scanned, would change/rewrote X, Y non-ASCII token(s)."`)
+  so an interactive caller gets feedback even though the data.frame
+  result is still returned invisibly. Wrap the call in
+  `suppressMessages()` to silence it.
+
 # checkhelper 1.0.0
 
 ## New features

--- a/R/asciify_pkg.R
+++ b/R/asciify_pkg.R
@@ -584,6 +584,11 @@ collect_pkg_files <- function(path, scope, ignore_ext) {
 #' @return invisibly, a data.frame with one row per inspected file:
 #'   `path`, `changed` (logical), `n_tokens`. The full rewritten content is
 #'   not returned to keep the result printable.
+#'
+#'   A one-line summary is also emitted via [base::message()] so an
+#'   interactive caller gets feedback even though the data.frame itself is
+#'   returned invisibly. Wrap the call in [base::suppressMessages()] to
+#'   silence it in scripts.
 #' @export
 #'
 #' @examples
@@ -641,6 +646,18 @@ asciify_pkg <- function(path = ".",
     path = character(), changed = logical(),
     n_tokens = integer(), stringsAsFactors = FALSE
   )
+
+  # Interactive feedback: the data.frame is returned invisibly (intentional,
+  # so it doesn't spam the console on big packages), but a console caller
+  # still gets a one-line summary. Silenceable via suppressMessages().
+  n_changed <- sum(out$changed, na.rm = TRUE)
+  n_tokens <- sum(out$n_tokens, na.rm = TRUE)
+  verb <- if (isTRUE(dry_run)) "would change" else "rewrote"
+  message(sprintf(
+    "asciify_pkg: %d file(s) scanned, %s %d, %d non-ASCII token(s).",
+    nrow(out), verb, n_changed, n_tokens
+  ))
+
   invisible(out)
 }
 

--- a/man/asciify_pkg.Rd
+++ b/man/asciify_pkg.Rd
@@ -48,6 +48,11 @@ surface and is not safe to automate.
 invisibly, a data.frame with one row per inspected file:
 \code{path}, \code{changed} (logical), \code{n_tokens}. The full rewritten content is
 not returned to keep the result printable.
+
+A one-line summary is also emitted via \code{\link[base:message]{base::message()}} so an
+interactive caller gets feedback even though the data.frame itself is
+returned invisibly. Wrap the call in \code{\link[base:message]{base::suppressMessages()}} to
+silence it in scripts.
 }
 \description{
 Walks the package tree, applies \code{\link[=asciify_file]{asciify_file()}} to each \code{R} /

--- a/tests/testthat/test-asciify-edge-cases.R
+++ b/tests/testthat/test-asciify-edge-cases.R
@@ -228,3 +228,49 @@ test_that("asciify_pkg() returns its summary invisibly", {
   )$visible
   expect_false(visible)
 })
+
+# ---- interactive feedback: summary message ---------------------------------
+
+test_that("asciify_pkg() emits a 'would change' message in dry_run", {
+  withr::with_tempdir({
+    dir.create("R")
+    writeLines(paste0("x <- \"caf", e, "\""), "R/f.R", useBytes = FALSE)
+    expect_message(
+      asciify_pkg(".", dry_run = TRUE),
+      regexp = "would change"
+    )
+  })
+})
+
+test_that("asciify_pkg() emits a 'rewrote' message in apply mode", {
+  withr::with_tempdir({
+    dir.create("R")
+    writeLines(paste0("x <- \"caf", e, "\""), "R/f.R", useBytes = FALSE)
+    expect_message(
+      asciify_pkg(".", dry_run = FALSE),
+      regexp = "rewrote"
+    )
+  })
+})
+
+test_that("asciify_pkg() summary message reports correct counts", {
+  withr::with_tempdir({
+    dir.create("R")
+    writeLines(paste0("x <- \"caf", e, "\""), "R/f1.R", useBytes = FALSE)
+    writeLines("x <- 1", "R/f2.R", useBytes = FALSE)  # ASCII-clean
+    expect_message(
+      asciify_pkg(".", dry_run = TRUE),
+      regexp = "2 file\\(s\\) scanned, would change 1, 1 non-ASCII token"
+    )
+  })
+})
+
+test_that("asciify_pkg() message is silenceable", {
+  withr::with_tempdir({
+    dir.create("R")
+    writeLines(paste0("x <- \"caf", e, "\""), "R/f.R", useBytes = FALSE)
+    expect_no_message(
+      suppressMessages(asciify_pkg(".", dry_run = TRUE))
+    )
+  })
+})


### PR DESCRIPTION
## Summary

`asciify_pkg()` returns its summary `invisible()` — intentional, so it doesn't dump a 200-row data.frame on a big package. But at the REPL that means the call looks like a no-op: no print, no feedback, the data.frame silently lost unless the caller assigned it.

This PR adds a one-line `message()` so an interactive user gets feedback while the data.frame contract stays unchanged:

```
> checkhelper::asciify_pkg(".")
asciify_pkg: 12 file(s) scanned, would change 3, 47 non-ASCII token(s).
> _
```

The verb tracks `dry_run`:
- `dry_run = TRUE`  → `"would change"`
- `dry_run = FALSE` → `"rewrote"`

Silenceable via `suppressMessages()`. The data.frame return shape is identical and still `invisible()`, so any existing scripted use (`preview <- asciify_pkg(".")`) keeps working byte-for-byte.

## Why message() and not print()?

- `print()` would force-print the whole data.frame (the original complaint).
- A classed return + `print.asciify_summary()` method only fires when R auto-prints — and `invisible()` blocks auto-print, so the method would never run.
- `message()` separates feedback (always emitted) from data (still invisible), and is the idiomatic R pattern (usethis, devtools all do this).

## Test plan

- [x] `expect_message(asciify_pkg(., dry_run = TRUE), "would change")`
- [x] `expect_message(asciify_pkg(., dry_run = FALSE), "rewrote")`
- [x] Counts in the message match the actual scan (file count, changed count, token count)
- [x] `suppressMessages(asciify_pkg(.))` silences it
- [x] Existing invisibility test still passes (already wraps in `suppressMessages()`)
- [x] Full local suite: `[ FAIL 0 | WARN 0 | SKIP 2 | PASS 158 ]` (154 baseline + 4 new)