### PR TITLE
fix(asciify): count non-ASCII characters in summary, add n_chars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,13 @@
 
 ## Minor changes
 
-- `asciify_pkg()` now emits a one-line summary message
-  (`"N file(s) scanned, would change/rewrote X, Y non-ASCII token(s)."`)
-  so an interactive caller gets feedback even though the data.frame
-  result is still returned invisibly. Wrap the call in
-  `suppressMessages()` to silence it.
+- `asciify_pkg()` now prints a one-line summary of how many files were
+  scanned, changed, and how many non-ASCII characters were found. In
+  dry-run mode it also prints how to apply the rewrite and how to
+  inspect the per-file detail. Use `suppressMessages()` to silence.
+- `asciify_pkg()` and `asciify_file()` gain an `n_chars` column /
+  list element: the count of non-ASCII characters in the original
+  file. `n_tokens` (number of source locations to rewrite) is kept.
 
 # checkhelper 1.0.0
 

--- a/R/asciify_pkg.R
+++ b/R/asciify_pkg.R
@@ -342,11 +342,14 @@ char_right <- function(line, from) {
 #' @param dry_run logical. If `TRUE`, report what would change but do not
 #'   write the file. Default `FALSE`.
 #'
-#' @return invisibly, a list with `path`, `changed` (logical), `n_tokens`
-#'   (integer; for R/Rmd/qmd, the count of non-ASCII parser tokens; for
-#'   any other file type — including `.Rnw` — the count of non-ASCII
-#'   characters), and `text` (the rewritten content if `changed`, else
-#'   the original).
+#' @return invisibly, a list with:
+#'   - `path`: path of the file
+#'   - `changed`: `TRUE` if the file was rewritten (or would be in dry-run)
+#'   - `n_chars`: number of non-ASCII characters in the file
+#'   - `n_tokens`: number of distinct source locations to rewrite
+#'     (an accented string literal counts once regardless of how many
+#'     non-ASCII characters it contains)
+#'   - `text`: rewritten content if `changed`, else the original
 #' @export
 asciify_file <- function(path,
                          strategy = c("auto", "escape", "translit", "report"),
@@ -358,7 +361,10 @@ asciify_file <- function(path,
 
   raw <- readLines(path, warn = FALSE, encoding = "UTF-8")
   if (!length(raw)) {
-    return(invisible(list(path = path, changed = FALSE, n_tokens = 0L, text = "")))
+    return(invisible(list(
+      path = path, changed = FALSE,
+      n_tokens = 0L, n_chars = 0L, text = ""
+    )))
   }
 
   # readLines() drops the trailing-newline status; capture it from bytes so
@@ -366,11 +372,12 @@ asciify_file <- function(path,
   trailing_nl <- has_trailing_newline(path)
 
   text <- paste(raw, collapse = "\n")
+  n_chars <- count_nonascii_chars(text)
   ext <- tolower(tools::file_ext(path))
   if (!ext %in% c("r", "rmd", "qmd")) {
     return(invisible(list(
       path = path, changed = FALSE,
-      n_tokens = count_nonascii_chars(text),
+      n_tokens = n_chars, n_chars = n_chars,
       text = text
     )))
   }
@@ -400,6 +407,7 @@ asciify_file <- function(path,
     path = path,
     changed = changed,
     n_tokens = n_tokens,
+    n_chars = n_chars,
     text = new
   ))
 }
@@ -582,13 +590,17 @@ collect_pkg_files <- function(path, scope, ignore_ext) {
 #' @param dry_run logical, default `TRUE` for safety. Pass `FALSE` to write.
 #'
 #' @return invisibly, a data.frame with one row per inspected file:
-#'   `path`, `changed` (logical), `n_tokens`. The full rewritten content is
-#'   not returned to keep the result printable.
+#'   - `path`: path of the file
+#'   - `changed`: `TRUE` if the file was rewritten (or would be in dry-run)
+#'   - `n_chars`: number of non-ASCII characters in the file
+#'   - `n_tokens`: number of distinct source locations to rewrite
+#'     (an accented string literal counts once regardless of how many
+#'     non-ASCII characters it contains)
 #'
-#'   A one-line summary is also emitted via [base::message()] so an
-#'   interactive caller gets feedback even though the data.frame itself is
-#'   returned invisibly. Wrap the call in [base::suppressMessages()] to
-#'   silence it in scripts.
+#'   A one-line summary is also printed via [base::message()]; in
+#'   dry-run mode it includes how to apply the rewrite and how to
+#'   inspect the per-file detail. Wrap the call in
+#'   [base::suppressMessages()] to silence.
 #' @export
 #'
 #' @examples
@@ -632,31 +644,44 @@ asciify_pkg <- function(path = ".",
       error = function(e) {
         warning(sprintf("asciify_pkg: skipping %s \u2014 %s", f, conditionMessage(e)),
                 call. = FALSE)
-        list(path = f, changed = FALSE, n_tokens = NA_integer_)
+        list(path = f, changed = FALSE,
+             n_tokens = NA_integer_, n_chars = NA_integer_)
       }
     )
     data.frame(
       path = res$path,
       changed = res$changed,
       n_tokens = res$n_tokens %||% 0L,
+      n_chars = res$n_chars %||% 0L,
       stringsAsFactors = FALSE
     )
   })
   out <- if (length(rows)) do.call(rbind, rows) else data.frame(
     path = character(), changed = logical(),
-    n_tokens = integer(), stringsAsFactors = FALSE
+    n_tokens = integer(), n_chars = integer(),
+    stringsAsFactors = FALSE
   )
 
-  # Interactive feedback: the data.frame is returned invisibly (intentional,
-  # so it doesn't spam the console on big packages), but a console caller
-  # still gets a one-line summary. Silenceable via suppressMessages().
   n_changed <- sum(out$changed, na.rm = TRUE)
-  n_tokens <- sum(out$n_tokens, na.rm = TRUE)
+  n_chars <- sum(out$n_chars, na.rm = TRUE)
   verb <- if (isTRUE(dry_run)) "would change" else "rewrote"
-  message(sprintf(
-    "asciify_pkg: %d file(s) scanned, %s %d, %d non-ASCII token(s).",
-    nrow(out), verb, n_changed, n_tokens
-  ))
+  lines <- sprintf(
+    "asciify_pkg: %d file(s) scanned, %s %d, %d non-ASCII character(s).",
+    nrow(out), verb, n_changed, n_chars
+  )
+  if (n_changed > 0L) {
+    if (isTRUE(dry_run)) {
+      lines <- c(lines, "* Re-run with `dry_run = FALSE` to apply.")
+    }
+    lines <- c(
+      lines,
+      paste(
+        "* Result returned invisibly; capture it (`out <- asciify_pkg(...)`)",
+        "or `print(asciify_pkg(...))` for per-file detail."
+      )
+    )
+  }
+  message(paste(lines, collapse = "\n"))
 
   invisible(out)
 }

--- a/man/asciify_file.Rd
+++ b/man/asciify_file.Rd
@@ -43,11 +43,16 @@ surface and is not safe to automate.
 write the file. Default \code{FALSE}.}
 }
 \value{
-invisibly, a list with \code{path}, \code{changed} (logical), \code{n_tokens}
-(integer; for R/Rmd/qmd, the count of non-ASCII parser tokens; for
-any other file type — including \code{.Rnw} — the count of non-ASCII
-characters), and \code{text} (the rewritten content if \code{changed}, else
-the original).
+invisibly, a list with:
+\itemize{
+\item \code{path}: path of the file
+\item \code{changed}: \code{TRUE} if the file was rewritten (or would be in dry-run)
+\item \code{n_chars}: number of non-ASCII characters in the file
+\item \code{n_tokens}: number of distinct source locations to rewrite
+(an accented string literal counts once regardless of how many
+non-ASCII characters it contains)
+\item \code{text}: rewritten content if \code{changed}, else the original
+}
 }
 \description{
 Writes the rewritten file in place (unless \code{dry_run = TRUE}). Files that

--- a/man/asciify_pkg.Rd
+++ b/man/asciify_pkg.Rd
@@ -46,13 +46,19 @@ surface and is not safe to automate.
 }
 \value{
 invisibly, a data.frame with one row per inspected file:
-\code{path}, \code{changed} (logical), \code{n_tokens}. The full rewritten content is
-not returned to keep the result printable.
+\itemize{
+\item \code{path}: path of the file
+\item \code{changed}: \code{TRUE} if the file was rewritten (or would be in dry-run)
+\item \code{n_chars}: number of non-ASCII characters in the file
+\item \code{n_tokens}: number of distinct source locations to rewrite
+(an accented string literal counts once regardless of how many
+non-ASCII characters it contains)
+}
 
-A one-line summary is also emitted via \code{\link[base:message]{base::message()}} so an
-interactive caller gets feedback even though the data.frame itself is
-returned invisibly. Wrap the call in \code{\link[base:message]{base::suppressMessages()}} to
-silence it in scripts.
+A one-line summary is also printed via \code{\link[base:message]{base::message()}}; in
+dry-run mode it includes how to apply the rewrite and how to
+inspect the per-file detail. Wrap the call in
+\code{\link[base:message]{base::suppressMessages()}} to silence.
 }
 \description{
 Walks the package tree, applies \code{\link[=asciify_file]{asciify_file()}} to each \code{R} /

--- a/tests/testthat/test-asciify-edge-cases.R
+++ b/tests/testthat/test-asciify-edge-cases.R
@@ -260,7 +260,22 @@ test_that("asciify_pkg() summary message reports correct counts", {
     writeLines("x <- 1", "R/f2.R", useBytes = FALSE)  # ASCII-clean
     expect_message(
       asciify_pkg(".", dry_run = TRUE),
-      regexp = "2 file\\(s\\) scanned, would change 1, 1 non-ASCII token"
+      regexp = "2 file\\(s\\) scanned, would change 1, 1 non-ASCII character"
+    )
+  })
+})
+
+test_that("asciify_pkg() summary counts every non-ASCII character, not parser tokens", {
+  withr::with_tempdir({
+    dir.create("R")
+    a <- "\u00e0"; e2 <- "\u00e9"; c2 <- "\u00e7"; e3 <- "\u00e8"
+    writeLines(
+      paste0("x <- \"hsl(50", a, e2, c2, e3, "%)\""),
+      "R/f.R", useBytes = FALSE
+    )
+    expect_message(
+      asciify_pkg(".", dry_run = TRUE),
+      regexp = "4 non-ASCII character"
     )
   })
 })
@@ -272,5 +287,48 @@ test_that("asciify_pkg() message is silenceable", {
     expect_no_message(
       suppressMessages(asciify_pkg(".", dry_run = TRUE))
     )
+  })
+})
+
+test_that("asciify_pkg() hints to re-run with dry_run = FALSE in dry-run with changes", {
+  withr::with_tempdir({
+    dir.create("R")
+    writeLines(paste0("x <- \"caf", e, "\""), "R/f.R", useBytes = FALSE)
+    expect_message(
+      asciify_pkg(".", dry_run = TRUE),
+      regexp = "Re-run with .*dry_run = FALSE.* to apply"
+    )
+  })
+})
+
+test_that("asciify_pkg() hints how to inspect the invisible result when there are changes", {
+  withr::with_tempdir({
+    dir.create("R")
+    writeLines(paste0("x <- \"caf", e, "\""), "R/f.R", useBytes = FALSE)
+    expect_message(
+      asciify_pkg(".", dry_run = TRUE),
+      regexp = "returned invisibly.*print\\(asciify_pkg"
+    )
+  })
+})
+
+test_that("asciify_pkg() does not show the apply hint when in apply mode", {
+  withr::with_tempdir({
+    dir.create("R")
+    writeLines(paste0("x <- \"caf", e, "\""), "R/f.R", useBytes = FALSE)
+    msgs <- testthat::capture_messages(asciify_pkg(".", dry_run = FALSE))
+    expect_false(any(grepl("dry_run = FALSE.* to apply", msgs)))
+  })
+})
+
+test_that("asciify_pkg() does not show hints when nothing would change", {
+  withr::with_tempdir({
+    dir.create("R")
+    writeLines("x <- 1", "R/f.R", useBytes = FALSE)  # ASCII-clean
+    msgs <- testthat::capture_messages(asciify_pkg(".", dry_run = TRUE))
+    expect_false(any(grepl("Re-run with", msgs)))
+    expect_false(any(grepl("returned invisibly", msgs)))
+    # but the count summary still appears
+    expect_true(any(grepl("would change 0", msgs)))
   })
 })


### PR DESCRIPTION
## Summary

The summary line printed by `asciify_pkg()` reported `n_tokens` (parser tokens), which made it look like a counting bug:

```r
# 4 glued non-ASCII chars in one string literal
> asciify_pkg(".")
asciify_pkg: 1 file(s) scanned, would change 1, 1 non-ASCII token(s).
#                                              ^
#                                              "1" instead of the expected "4"
```

The number was technically right (1 string literal = 1 parser token = 1 location to rewrite), but it doesn't match what a user reads when they grep their source for accents — and it doesn't match what CRAN itself surfaces (CRAN reports per-character occurrences).

## What this PR does

- Switch the summary headline to **non-ASCII character count**:
  ```
  asciify_pkg: 1 file(s) scanned, would change 1, 4 non-ASCII character(s).
  ```
- Surface the new count on the data.frame:
  - `asciify_pkg()` data.frame gains an `n_chars` column
  - `asciify_file()` return list gains an `n_chars` element
- Keep `n_tokens` (parser token count = number of distinct source locations to rewrite). It's still useful, just not the right number for a user-facing total.

## Follow-up to #97

PR #97 added the summary message but used `n_tokens` for the headline number (oversight). This PR fixes that, and also tightens the dry-run hints so the message reads cleanly:

```
asciify_pkg: 12 file(s) scanned, would change 3, 47 non-ASCII character(s).
* Re-run with `dry_run = FALSE` to apply.
* Result returned invisibly; capture it (`out <- asciify_pkg(...)`) or `print(asciify_pkg(...))` for per-file detail.
```

## Test plan

- [x] Regression for the 4-glued-accents bug (`"hsl(50àéçè%)"` → reports 4, not 1)
- [x] Existing summary-count test updated to "non-ASCII character"
- [x] All previous message tests still pass (verb selection, suppression, hint gating)
- [x] Full local suite: `[ FAIL 0 | WARN 0 | SKIP 2 | PASS 165 ]` (158 → 165)

## Stranded branch

The `feat/asciify-pkg-summary-message` branch was re-created on the remote when I pushed the (now squash-merged) follow-up commit by mistake. It carries no useful state and can be deleted whenever convenient — happy to do it once authorized, otherwise it's harmless to leave.