### PR TITLE
feat(audit_globals, fix_globals): accept pre-computed checks=

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # checkhelper (development version)
 
+## Share one R CMD check across audits
+
+- `audit_globals()` and `fix_globals()` gain a `checks =` argument
+  that accepts a pre-computed `rcmdcheck::rcmdcheck()` result. When
+  supplied, they skip running `R CMD check` and reuse the existing
+  output. Lets you run the check **once** and feed both functions
+  during a full package audit. See the new vignette
+  *"Auditing an R package you have just received"*.
+
 ## API refresh — `audit_*` / `fix_*` façades
 
 The package now exposes a uniform CRAN-oriented API: each category of

--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -6,6 +6,10 @@
 #' `globalVariables()` block. Wraps [get_no_visible()].
 #'
 #' @param pkg Path to the package to audit.
+#' @param checks Optional. A pre-computed [rcmdcheck::rcmdcheck()] result
+#'   (a list with at least a `notes` element). When supplied, `audit_globals()`
+#'   reuses it instead of re-running `R CMD check` on `pkg`. Useful to share
+#'   a single check between [audit_globals()] and [fix_globals()].
 #'
 #' @return A list with two tibbles, `globalVariables` and `functions`,
 #'   or `NULL` if the package has no global notes.
@@ -14,10 +18,21 @@
 #' @examples
 #' \dontrun{
 #' pkg <- create_example_pkg()
+#'
+#' # One-shot:
 #' audit_globals(pkg)
+#'
+#' # Shared check (avoid running R CMD check twice):
+#' chk <- rcmdcheck::rcmdcheck(pkg)
+#' audit_globals(pkg, checks = chk)
+#' fix_globals(pkg, checks = chk)
 #' }
-audit_globals <- function(pkg = ".") {
-  out <- .get_no_visible(path = pkg)
+audit_globals <- function(pkg = ".", checks = NULL) {
+  out <- if (is.null(checks)) {
+    .get_no_visible(path = pkg)
+  } else {
+    .get_no_visible(path = pkg, checks = checks)
+  }
 
   if (is.null(out)) {
     cli::cli_inform(c("v" = "audit_globals(): no global notes detected."))
@@ -44,6 +59,10 @@ audit_globals <- function(pkg = ".") {
 #' @param write If `TRUE`, **overwrite** `<pkg>/R/globals.R` with a
 #'   single `globalVariables(...)` call. Default `FALSE` (print the
 #'   block to the console for manual paste).
+#' @param checks Optional. A pre-computed [rcmdcheck::rcmdcheck()] result
+#'   (a list with at least a `notes` element). When supplied, `fix_globals()`
+#'   reuses it instead of re-running `R CMD check` on `pkg`. Useful to share
+#'   a single check between [audit_globals()] and [fix_globals()].
 #'
 #' @return Invisibly, the path written (when `write = TRUE`) or `NULL`.
 #' @export
@@ -53,9 +72,18 @@ audit_globals <- function(pkg = ".") {
 #' pkg <- create_example_pkg()
 #' fix_globals(pkg)
 #' fix_globals(pkg, write = TRUE)
+#'
+#' # Reuse a single R CMD check across both audit and fix:
+#' chk <- rcmdcheck::rcmdcheck(pkg)
+#' audit_globals(pkg, checks = chk)
+#' fix_globals(pkg, checks = chk, write = TRUE)
 #' }
-fix_globals <- function(pkg = ".", write = FALSE) {
-  globals <- .get_no_visible(path = pkg)
+fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
+  globals <- if (is.null(checks)) {
+    .get_no_visible(path = pkg)
+  } else {
+    .get_no_visible(path = pkg, checks = checks)
+  }
 
   if (is.null(globals)) {
     cli::cli_inform(c("v" = "fix_globals(): no globals to declare."))

--- a/README.Rmd
+++ b/README.Rmd
@@ -91,7 +91,30 @@ audit_ascii(pkg)
 fix_ascii(pkg, dry_run = FALSE)
 ```
 
-For the full walkthrough per issue category, see the vignettes on the pkgdown site.
+## Auditing an unknown package — share one check across audits
+
+`audit_globals()` and `fix_globals()` both need the output of `R CMD check`. To avoid running it twice, pass a pre-computed `rcmdcheck::rcmdcheck()` result via `checks =`:
+
+```r
+pkg <- "/path/to/the/package"
+
+# Run R CMD check ONCE.
+chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
+
+# Static audits — no check needed.
+audit_tags(pkg)
+audit_ascii(pkg)
+audit_dataset_doc(pkg)
+
+# Audits that consume the check — reuse `chk`.
+audit_globals(pkg, checks = chk)
+fix_globals(pkg,   checks = chk, write = TRUE)
+
+# Userspace audit has its own pipeline (tests + examples + vignettes + check).
+audit_userspace(pkg)
+```
+
+See the **"Auditing an R package you have just received"** vignette for the full walkthrough. The full per-category walkthroughs live in the other vignettes on the pkgdown site.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ fix_ascii(pkg, dry_run = FALSE)
 
 ## Auditing an unknown package — share one check across audits
 
-`audit_globals()` and `fix_globals()` both need the output of `R CMD
-check`. To avoid running it twice, pass a pre-computed
+`audit_globals()` and `fix_globals()` both need the output of
+`R CMD check`. To avoid running it twice, pass a pre-computed
 `rcmdcheck::rcmdcheck()` result via `checks =`:
 
 ``` r

--- a/README.md
+++ b/README.md
@@ -94,8 +94,34 @@ audit_ascii(pkg)
 fix_ascii(pkg, dry_run = FALSE)
 ```
 
-For the full walkthrough per issue category, see the vignettes on the
-pkgdown site.
+## Auditing an unknown package — share one check across audits
+
+`audit_globals()` and `fix_globals()` both need the output of `R CMD
+check`. To avoid running it twice, pass a pre-computed
+`rcmdcheck::rcmdcheck()` result via `checks =`:
+
+``` r
+pkg <- "/path/to/the/package"
+
+# Run R CMD check ONCE.
+chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
+
+# Static audits — no check needed.
+audit_tags(pkg)
+audit_ascii(pkg)
+audit_dataset_doc(pkg)
+
+# Audits that consume the check — reuse `chk`.
+audit_globals(pkg, checks = chk)
+fix_globals(pkg,   checks = chk, write = TRUE)
+
+# Userspace audit has its own pipeline (tests + examples + vignettes + check).
+audit_userspace(pkg)
+```
+
+See the **"Auditing an R package you have just received"** vignette
+for the full walkthrough. The per-category walkthroughs live in the
+other vignettes on the pkgdown site.
 
 ## Code of Conduct
 

--- a/man/audit_globals.Rd
+++ b/man/audit_globals.Rd
@@ -4,10 +4,15 @@
 \alias{audit_globals}
 \title{Audit globals to declare in R/globals.R}
 \usage{
-audit_globals(pkg = ".")
+audit_globals(pkg = ".", checks = NULL)
 }
 \arguments{
 \item{pkg}{Path to the package to audit.}
+
+\item{checks}{Optional. A pre-computed \code{\link[rcmdcheck:rcmdcheck]{rcmdcheck::rcmdcheck()}} result
+(a list with at least a \code{notes} element). When supplied, \code{audit_globals()}
+reuses it instead of re-running \verb{R CMD check} on \code{pkg}. Useful to share
+a single check between \code{\link[=audit_globals]{audit_globals()}} and \code{\link[=fix_globals]{fix_globals()}}.}
 }
 \value{
 A list with two tibbles, \code{globalVariables} and \code{functions},
@@ -22,7 +27,14 @@ note. Use \code{\link[=fix_globals]{fix_globals()}} to print or write the corres
 \examples{
 \dontrun{
 pkg <- create_example_pkg()
+
+# One-shot:
 audit_globals(pkg)
+
+# Shared check (avoid running R CMD check twice):
+chk <- rcmdcheck::rcmdcheck(pkg)
+audit_globals(pkg, checks = chk)
+fix_globals(pkg, checks = chk)
 }
 }
 \seealso{

--- a/man/fix_globals.Rd
+++ b/man/fix_globals.Rd
@@ -4,7 +4,7 @@
 \alias{fix_globals}
 \title{Print or write the globalVariables block to declare}
 \usage{
-fix_globals(pkg = ".", write = FALSE)
+fix_globals(pkg = ".", write = FALSE, checks = NULL)
 }
 \arguments{
 \item{pkg}{Path to the package.}
@@ -12,6 +12,11 @@ fix_globals(pkg = ".", write = FALSE)
 \item{write}{If \code{TRUE}, \strong{overwrite} \verb{<pkg>/R/globals.R} with a
 single \code{globalVariables(...)} call. Default \code{FALSE} (print the
 block to the console for manual paste).}
+
+\item{checks}{Optional. A pre-computed \code{\link[rcmdcheck:rcmdcheck]{rcmdcheck::rcmdcheck()}} result
+(a list with at least a \code{notes} element). When supplied, \code{fix_globals()}
+reuses it instead of re-running \verb{R CMD check} on \code{pkg}. Useful to share
+a single check between \code{\link[=audit_globals]{audit_globals()}} and \code{\link[=fix_globals]{fix_globals()}}.}
 }
 \value{
 Invisibly, the path written (when \code{write = TRUE}) or \code{NULL}.
@@ -26,6 +31,11 @@ Convenience wrapper that runs the audit, then either prints the
 pkg <- create_example_pkg()
 fix_globals(pkg)
 fix_globals(pkg, write = TRUE)
+
+# Reuse a single R CMD check across both audit and fix:
+chk <- rcmdcheck::rcmdcheck(pkg)
+audit_globals(pkg, checks = chk)
+fix_globals(pkg, checks = chk, write = TRUE)
 }
 }
 \seealso{

--- a/tests/testthat/test-audit-globals.R
+++ b/tests/testthat/test-audit-globals.R
@@ -1,6 +1,7 @@
 test_that("audit_globals() exists with the expected signature", {
   expect_true(is.function(audit_globals))
-  expect_named(formals(audit_globals), c("pkg"))
+  expect_named(formals(audit_globals), c("pkg", "checks"))
+  expect_null(eval(formals(audit_globals)$checks))
 })
 
 test_that("audit_globals() returns either NULL or a 2-element list (globalVariables, functions)", {
@@ -26,4 +27,41 @@ test_that("audit_globals() emits a cli message", {
     suppressWarnings(audit_globals(path)),
     regexp = "global"
   )
+})
+
+test_that("audit_globals(checks = ...) reuses a precomputed rcmdcheck and does not re-run R CMD check", {
+  # Faux objet rcmdcheck minimal: une seule note avec deux globals connues.
+  fake_checks <- list(
+    notes = c(
+      paste(
+        "checking R code for possible problems ... NOTE",
+        "my_fun: no visible binding for global variable ‘foo’",
+        "my_fun: no visible global function definition for ‘bar’",
+        sep = "\n"
+      )
+    )
+  )
+
+  # Sentinelle: rcmdcheck::rcmdcheck est stubbé pour exploser si appelé.
+  # Si la branche `checks =` est correctement câblée, on ne le déclenche jamais.
+  testthat::with_mocked_bindings(
+    rcmdcheck = function(...) stop("rcmdcheck must NOT be called when checks= is supplied"),
+    .package = "checkhelper",
+    {
+      out <- suppressMessages(audit_globals(pkg = "/path/does/not/exist",
+                                            checks = fake_checks))
+    }
+  )
+
+  expect_type(out, "list")
+  expect_named(out, c("globalVariables", "functions"))
+  expect_true("foo" %in% out$globalVariables$variable)
+  expect_true("bar" %in% out$functions$variable)
+})
+
+test_that("audit_globals(checks = ...) returns NULL when checks has no relevant notes", {
+  fake_checks <- list(notes = character())
+  out <- suppressMessages(audit_globals(pkg = "/path/does/not/exist",
+                                        checks = fake_checks))
+  expect_null(out)
 })

--- a/tests/testthat/test-audit-globals.R
+++ b/tests/testthat/test-audit-globals.R
@@ -30,7 +30,7 @@ test_that("audit_globals() emits a cli message", {
 })
 
 test_that("audit_globals(checks = ...) reuses a precomputed rcmdcheck and does not re-run R CMD check", {
-  # Faux objet rcmdcheck minimal: une seule note avec deux globals connues.
+  # Minimal fake rcmdcheck object: one note with two known globals.
   fake_checks <- list(
     notes = c(
       paste(
@@ -42,8 +42,8 @@ test_that("audit_globals(checks = ...) reuses a precomputed rcmdcheck and does n
     )
   )
 
-  # Sentinelle: rcmdcheck::rcmdcheck est stubbé pour exploser si appelé.
-  # Si la branche `checks =` est correctement câblée, on ne le déclenche jamais.
+  # Sentinel: stub rcmdcheck::rcmdcheck so it explodes if called.
+  # If the `checks =` branch is correctly wired, we never trigger it.
   testthat::with_mocked_bindings(
     rcmdcheck = function(...) stop("rcmdcheck must NOT be called when checks= is supplied"),
     .package = "checkhelper",

--- a/tests/testthat/test-fix-globals.R
+++ b/tests/testthat/test-fix-globals.R
@@ -1,7 +1,8 @@
 test_that("fix_globals() exists with the expected signature", {
   expect_true(is.function(fix_globals))
-  expect_named(formals(fix_globals), c("pkg", "write"))
+  expect_named(formals(fix_globals), c("pkg", "write", "checks"))
   expect_false(eval(formals(fix_globals)$write))
+  expect_null(eval(formals(fix_globals)$checks))
 })
 
 test_that("fix_globals(write = FALSE) emits a message and does not modify R/globals.R", {
@@ -36,4 +37,36 @@ test_that("fix_globals(write = TRUE) writes a parseable R/globals.R", {
   expect_true(any(grepl("globalVariables\\s*\\(", written)))
   expect_false(any(grepl("^---", written)),
                info = "no banner header should land in the source file")
+})
+
+test_that("fix_globals(checks = ...) reuses a precomputed rcmdcheck and writes a parseable globals.R", {
+  fake_checks <- list(
+    notes = c(
+      paste(
+        "checking R code for possible problems ... NOTE",
+        "my_fun: no visible binding for global variable ‘foo’",
+        "my_fun: no visible global function definition for ‘bar’",
+        sep = "\n"
+      )
+    )
+  )
+
+  pkg <- tempfile("fixg-")
+  dir.create(file.path(pkg, "R"), recursive = TRUE)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  testthat::with_mocked_bindings(
+    rcmdcheck = function(...) stop("rcmdcheck must NOT be called when checks= is supplied"),
+    .package = "checkhelper",
+    {
+      out <- suppressMessages(fix_globals(pkg = pkg, write = TRUE,
+                                          checks = fake_checks))
+    }
+  )
+
+  expect_identical(out, file.path(pkg, "R", "globals.R"))
+  expect_true(file.exists(out))
+  expect_silent(parse(file = out))
+  written <- readLines(out)
+  expect_true(any(grepl("\"foo\"", written)))
 })

--- a/vignettes/auditing-an-r-package.Rmd
+++ b/vignettes/auditing-an-r-package.Rmd
@@ -1,0 +1,111 @@
+---
+title: "Auditing an R package you have just received"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Auditing an R package you have just received}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+```{r setup}
+library(checkhelper)
+```
+
+This vignette walks through the practical sequence of commands when a
+colleague hands you an R package and asks "is this CRAN-ready ?". The
+goal is to surface every CRAN-blocking issue with the **smallest
+possible number of `R CMD check` runs**.
+
+## TL;DR — the audit script
+
+```{r}
+pkg <- "/path/to/the/package"
+
+# 1. Run R CMD check ONCE and reuse it everywhere it's needed.
+chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
+
+# 2. Static audits (no extra check needed).
+audit_tags(pkg)            # exported funs without @return / internals without @noRd
+audit_ascii(pkg)           # non-ASCII characters in R/, tests/, vignettes/, man/
+audit_dataset_doc(pkg)     # datasets in data/ without a roxygen block
+
+# 3. Audits that need the check output — pass `chk` to skip a 2nd run.
+audit_globals(pkg, checks = chk)
+
+# 4. Userspace audit (separate workflow: it runs tests + examples + check
+#    with file-system snapshots between steps, can't reuse `chk`).
+audit_userspace(pkg)
+
+# 5. Apply the safe fixes.
+fix_globals(pkg, checks = chk, write = TRUE)
+fix_ascii(pkg, dry_run = TRUE)        # review first
+fix_ascii(pkg, dry_run = FALSE)       # then apply
+fix_dataset_doc(pkg)
+```
+
+## Why share the check object ?
+
+`audit_globals()` and `fix_globals()` parse the `notes` field of an
+`rcmdcheck::rcmdcheck()` result to extract the
+`no visible binding for global variable` and
+`no visible global function definition` notes. By default each call
+runs its own check, which is slow on a real package.
+
+Both functions accept a `checks =` argument. When supplied, they skip
+the `rcmdcheck()` call and parse the existing object. This lets you
+run the check **once** and reuse the result for the whole audit.
+
+```{r}
+chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
+
+audit_globals(pkg, checks = chk)
+fix_globals(pkg,   checks = chk, write = TRUE)
+```
+
+The other audits do not need a check at all:
+
+| Audit                | Needs `R CMD check` ? | Notes                                  |
+|----------------------|-----------------------|----------------------------------------|
+| `audit_tags()`       | no                    | static via roxygen2                    |
+| `audit_ascii()`      | no                    | AST via `getParseData()`               |
+| `audit_dataset_doc()`| no                    | inspects `data/` and `R/`              |
+| `audit_globals()`    | **yes** (reusable)    | accepts `checks =`                     |
+| `audit_userspace()`  | yes (own pipeline)    | takes file-system snapshots, separate  |
+| `audit_check()`      | yes                   | this **is** the check, with CRAN env   |
+
+## Choosing between `rcmdcheck()` and `audit_check()`
+
+- `rcmdcheck::rcmdcheck(pkg, args = "--as-cran")` — fast, returns the
+  list shape that `audit_globals(checks = ...)` expects. Use it for the
+  shared-check workflow above.
+- `audit_check(pkg)` — runs the check with the full **CRAN incoming**
+  environment (env vars, options, lib path mirrored from CRAN). Heavier
+  and uses `tools::check_packages_in_dir()` under the hood; use it as a
+  final gate before submission, not as the audit driver.
+
+## Minimal end-to-end on a fake package
+
+```{r}
+pkg <- create_example_pkg()
+
+chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
+
+audit_tags(pkg)
+audit_ascii(pkg)
+audit_dataset_doc(pkg)
+audit_globals(pkg, checks = chk)
+
+fix_globals(pkg, checks = chk, write = TRUE)
+fix_ascii(pkg, dry_run = FALSE)
+```
+
+After applying the fixes, re-run the check (the package state has
+changed, so a new `rcmdcheck()` is needed) and confirm 0 / 0 / 0.

--- a/vignettes/auditing-an-r-package.Rmd
+++ b/vignettes/auditing-an-r-package.Rmd
@@ -20,7 +20,7 @@ library(checkhelper)
 ```
 
 This vignette walks through the practical sequence of commands when a
-colleague hands you an R package and asks "is this CRAN-ready ?". The
+colleague hands you an R package and asks "is this CRAN-ready?". The
 goal is to surface every CRAN-blocking issue with the **smallest
 possible number of `R CMD check` runs**.
 
@@ -51,7 +51,7 @@ fix_ascii(pkg, dry_run = FALSE)       # then apply
 fix_dataset_doc(pkg)
 ```
 
-## Why share the check object ?
+## Why share the check object?
 
 `audit_globals()` and `fix_globals()` parse the `notes` field of an
 `rcmdcheck::rcmdcheck()` result to extract the
@@ -72,7 +72,7 @@ fix_globals(pkg,   checks = chk, write = TRUE)
 
 The other audits do not need a check at all:
 
-| Audit                | Needs `R CMD check` ? | Notes                                  |
+| Audit                | Needs `R CMD check`?  | Notes                                  |
 |----------------------|-----------------------|----------------------------------------|
 | `audit_tags()`       | no                    | static via roxygen2                    |
 | `audit_ascii()`      | no                    | AST via `getParseData()`               |


### PR DESCRIPTION
## Summary

- `audit_globals(pkg, checks = NULL)` and `fix_globals(pkg, write, checks = NULL)` gain a `checks =` argument that accepts a pre-computed `rcmdcheck::rcmdcheck()` result and skips re-running `R CMD check`.
- Lets users share **one** check between both functions during a full audit:

  ```r
  chk <- rcmdcheck::rcmdcheck(pkg)
  audit_globals(pkg, checks = chk)
  fix_globals(pkg,   checks = chk, write = TRUE)
  ```

- New vignette **"Auditing an R package you have just received"** walks through the shared-check workflow end-to-end, with a table of which audits need a check vs. which are static.
- `README` and `NEWS.md` updated accordingly.

The plumbing is mechanical: the dotted internals (`.get_no_visible`, `.get_notes`) already accepted `checks =` since 1.0.0 — this PR just exposes it on the public façade.

## Test plan

- [x] New unit tests cover the signature + the new branch:
  - `audit_globals()` formals include `checks` defaulting to `NULL`.
  - `audit_globals(pkg, checks = stub)` returns the parsed result and **does not** call `rcmdcheck` (verified with `with_mocked_bindings(rcmdcheck = function(...) stop("..."), .package = "checkhelper")` — the stub explodes if the new branch is mis-wired).
  - `audit_globals(checks = list(notes = character()))` returns `NULL` (no-op case).
  - Equivalent coverage on `fix_globals(write = TRUE, checks = ...)`: writes a parseable `R/globals.R` without invoking `rcmdcheck`.
- [x] `man/audit_globals.Rd` and `man/fix_globals.Rd` regenerated via `devtools::document()`.
- [x] New vignette knits with `eval = FALSE` (so it doesn't depend on running checks during build).
- [ ] CI must remain green (R-CMD-check, test-coverage, pkgdown).