### PR TITLE
chore: brace every if/for/while body across the package

### DIFF
--- a/R/asciify_helpers.R
+++ b/R/asciify_helpers.R
@@ -21,7 +21,7 @@
 #' @export
 find_nonascii_tokens <- function(text) {
   stopifnot(is.character(text), length(text) == 1L)
-  if (!nzchar(text)) return(empty_token_pd())
+  if (!nzchar(text)) { return(empty_token_pd()) }
 
   parsed <- tryCatch(
     parse(text = text, keep.source = TRUE),
@@ -35,7 +35,7 @@ find_nonascii_tokens <- function(text) {
   )
 
   pd <- utils::getParseData(parsed, includeText = TRUE)
-  if (is.null(pd) || !nrow(pd)) return(empty_token_pd())
+  if (is.null(pd) || !nrow(pd)) { return(empty_token_pd()) }
 
   pd <- pd[!is.na(pd$text) & nzchar(pd$text), , drop = FALSE]
   # `expr` rows wrap their children and would cause overlapping rewrites
@@ -59,7 +59,7 @@ find_nonascii_tokens <- function(text) {
 
   hits <- !stringi::stri_enc_isascii(pd$text)
   pd <- pd[hits, , drop = FALSE]
-  if (!nrow(pd)) return(empty_token_pd())
+  if (!nrow(pd)) { return(empty_token_pd()) }
 
   pd$is_identifier <- pd$token %in% c(
     "SYMBOL", "SYMBOL_FUNCTION_CALL",
@@ -84,7 +84,7 @@ isTRUE_each <- function(x) {
 #'   [find_nonascii_tokens()] to avoid an O(n_tokens) re-split).
 #' @noRd
 extract_token_source <- function(lines, row) {
-  if (row$line1 < 1L || row$line2 > length(lines)) return(row$text)
+  if (row$line1 < 1L || row$line2 > length(lines)) { return(row$text) }
   if (row$line1 == row$line2) {
     return(stringi::stri_sub(lines[row$line1], row$col1, row$col2))
   }
@@ -126,9 +126,9 @@ rewrite_nonascii_token <- function(text, token, strategy) {
     strategy,
     c("auto", "escape", "translit", "report")
   )
-  if (strategy == "report") return(text)
+  if (strategy == "report") { return(text) }
   if (strategy == "auto") {
-    strategy <- if (token == "STR_CONST") "escape" else "translit"
+    strategy <- if (token == "STR_CONST") { "escape" } else { "translit" }
   }
   if (strategy == "escape") {
     if (token == "STR_CONST") {
@@ -151,10 +151,10 @@ rewrite_nonascii_token <- function(text, token, strategy) {
 #'
 #' @noRd
 escape_chars_only <- function(text) {
-  if (stringi::stri_enc_isascii(text)) return(text)
+  if (stringi::stri_enc_isascii(text)) { return(text) }
   chars <- strsplit(text, "", fixed = TRUE)[[1L]]
   bad <- !stringi::stri_enc_isascii(chars)
-  if (!any(bad)) return(text)
+  if (!any(bad)) { return(text) }
   cps <- utf8ToInt(paste(chars[bad], collapse = ""))
   enc <- ifelse(
     cps <= 0xFFFFL,
@@ -252,7 +252,7 @@ asciify_r_source <- function(text,
   identifiers <- match.arg(identifiers)
 
   pd <- find_nonascii_tokens(text)
-  if (!nrow(pd)) return(text)
+  if (!nrow(pd)) { return(text) }
 
   bad_ids <- pd[pd$is_identifier, , drop = FALSE]
   if (nrow(bad_ids)) {
@@ -268,7 +268,7 @@ asciify_r_source <- function(text,
   }
 
   pd <- pd[!pd$is_identifier, , drop = FALSE]
-  if (!nrow(pd) || strategy == "report") return(text)
+  if (!nrow(pd) || strategy == "report") { return(text) }
 
   # Process tokens from end to start so earlier byte/char offsets stay valid.
   pd <- pd[order(-pd$line1, -pd$col1), , drop = FALSE]
@@ -277,7 +277,7 @@ asciify_r_source <- function(text,
   # the round-trip preserves it.
   has_trailing_nl <- substr(text, nchar(text), nchar(text)) == "\n"
   lines <- strsplit(text, "\n", fixed = TRUE)[[1L]]
-  if (length(lines) == 0L) lines <- ""
+  if (length(lines) == 0L) { lines <- "" }
 
   for (i in seq_len(nrow(pd))) {
     tok <- pd[i, ]
@@ -291,13 +291,13 @@ asciify_r_source <- function(text,
       head <- char_left(lines[tok$line1], tok$col1 - 1L)
       tail <- char_right(lines[tok$line2], tok$col2 + 1L)
       new_lines <- strsplit(new, "\n", fixed = TRUE)[[1L]]
-      if (length(new_lines) == 0L) new_lines <- ""
+      if (length(new_lines) == 0L) { new_lines <- "" }
       new_lines[1L] <- paste0(head, new_lines[1L])
       new_lines[length(new_lines)] <- paste0(new_lines[length(new_lines)], tail)
       lines <- c(
-        if (tok$line1 > 1L) lines[seq_len(tok$line1 - 1L)],
+        if (tok$line1 > 1L) { lines[seq_len(tok$line1 - 1L)] },
         new_lines,
-        if (tok$line2 < length(lines)) lines[seq.int(tok$line2 + 1L, length(lines))]
+        if (tok$line2 < length(lines)) { lines[seq.int(tok$line2 + 1L, length(lines))] }
       )
     }
   }
@@ -320,12 +320,12 @@ char_splice <- function(line, col1, col2, replacement) {
 
 #' @noRd
 char_left <- function(line, n) {
-  if (n <= 0L) "" else stringi::stri_sub(line, 1L, n)
+  if (n <= 0L) { "" } else { stringi::stri_sub(line, 1L, n) }
 }
 
 #' @noRd
 char_right <- function(line, from) {
-  if (from > stringi::stri_length(line)) "" else stringi::stri_sub(line, from, -1L)
+  if (from > stringi::stri_length(line)) { "" } else { stringi::stri_sub(line, from, -1L) }
 }
 
 #' Apply the asciify rewrite to a single R / R-related file
@@ -416,10 +416,10 @@ asciify_file <- function(path,
 sum_chunk_nonascii_tokens <- function(text) {
   rx <- "(?ms)^([ \\t]*```\\{r[^\\n]*\\n)(.*?)(\\n[ \\t]*```\\s*$)"
   m <- regmatches(text, gregexpr(rx, text, perl = TRUE))[[1L]]
-  if (!length(m)) return(0L)
+  if (!length(m)) { return(0L) }
   bodies <- vapply(m, function(chunk) {
     parts <- regmatches(chunk, regexec(rx, chunk, perl = TRUE))[[1L]]
-    if (length(parts) >= 4L) parts[3L] else ""
+    if (length(parts) >= 4L) { parts[3L] } else { "" }
   }, character(1L))
   sum(vapply(bodies, function(b) nrow(find_nonascii_tokens_safe(b)),
              integer(1L)))
@@ -428,7 +428,7 @@ sum_chunk_nonascii_tokens <- function(text) {
 #' @noRd
 has_trailing_newline <- function(path) {
   size <- file.size(path)
-  if (is.na(size) || size == 0L) return(FALSE)
+  if (is.na(size) || size == 0L) { return(FALSE) }
   con <- file(path, "rb")
   on.exit(close(con))
   seek(con, where = size - 1L, origin = "start")
@@ -452,7 +452,7 @@ write_text_preserving_eol <- function(text, path, trailing_nl) {
 
 #' @noRd
 count_nonascii_chars <- function(text) {
-  if (!length(text) || !nzchar(text)) return(0L)
+  if (!length(text) || !nzchar(text)) { return(0L) }
   sum(!stringi::stri_enc_isascii(strsplit(text, "", fixed = TRUE)[[1L]]))
 }
 
@@ -467,7 +467,7 @@ asciify_rmd <- function(text, strategy, identifiers) {
   # Match ```{r ...} ... ``` chunks (knitr's standard form).
   rx <- "(?ms)^([ \\t]*```\\{r[^\\n]*\\n)(.*?)(\\n[ \\t]*```\\s*$)"
   m <- gregexpr(rx, text, perl = TRUE)[[1L]]
-  if (length(m) == 1L && m == -1L) return(text)
+  if (length(m) == 1L && m == -1L) { return(text) }
   starts <- as.integer(m)
   lengths <- attr(m, "match.length")
 
@@ -476,7 +476,7 @@ asciify_rmd <- function(text, strategy, identifiers) {
   for (i in ord) {
     chunk <- substr(text, starts[i], starts[i] + lengths[i] - 1L)
     parts <- regmatches(chunk, regexec(rx, chunk, perl = TRUE))[[1L]]
-    if (length(parts) < 4L) next
+    if (length(parts) < 4L) { next }
     head <- parts[2L]; body <- parts[3L]; tail <- parts[4L]
     new_body <- tryCatch(
       asciify_r_source(body, strategy = strategy, identifiers = identifiers),
@@ -525,14 +525,14 @@ asciify_rmd <- function(text, strategy, identifiers) {
     # file.size() returns NA for unreadable entries (e.g. broken symlinks);
     # skip silently rather than letting the >= comparison error out the scan.
     sz <- file.size(f)
-    if (is.na(sz) || sz >= size_limit) return(NULL)
+    if (is.na(sz) || sz >= size_limit) { return(NULL) }
     raw <- tryCatch(
       readLines(f, warn = FALSE, encoding = "UTF-8"),
       error = function(e) NULL
     )
-    if (is.null(raw) || !length(raw)) return(NULL)
+    if (is.null(raw) || !length(raw)) { return(NULL) }
     bad <- which(!stringi::stri_enc_isascii(raw))
-    if (!length(bad)) return(NULL)
+    if (!length(bad)) { return(NULL) }
     data.frame(
       file = f,
       line = bad,
@@ -558,7 +558,7 @@ collect_pkg_files <- function(path, scope, ignore_ext) {
   out <- character()
   for (s in scope) {
     p <- file.path(path, s)
-    if (!file.exists(p)) next
+    if (!file.exists(p)) { next }
     if (file.info(p)$isdir) {
       out <- c(out, list.files(p, recursive = TRUE, full.names = TRUE,
                                include.dirs = FALSE, no.. = TRUE))
@@ -642,15 +642,19 @@ collect_pkg_files <- function(path, scope, ignore_ext) {
       stringsAsFactors = FALSE
     )
   })
-  out <- if (length(rows)) do.call(rbind, rows) else data.frame(
-    path = character(), changed = logical(),
-    n_tokens = integer(), n_chars = integer(),
-    stringsAsFactors = FALSE
-  )
+  out <- if (length(rows)) {
+    do.call(rbind, rows)
+  } else {
+    data.frame(
+      path = character(), changed = logical(),
+      n_tokens = integer(), n_chars = integer(),
+      stringsAsFactors = FALSE
+    )
+  }
 
   n_changed <- sum(out$changed, na.rm = TRUE)
   n_chars <- sum(out$n_chars, na.rm = TRUE)
-  verb <- if (isTRUE(dry_run)) "would change" else "rewrote"
+  verb <- if (isTRUE(dry_run)) { "would change" } else { "rewrote" }
   lines <- sprintf(
     "asciify_pkg: %d file(s) scanned, %s %d, %d non-ASCII character(s).",
     nrow(out), verb, n_changed, n_chars
@@ -673,4 +677,4 @@ collect_pkg_files <- function(path, scope, ignore_ext) {
 }
 
 # tiny null-coalescer to avoid an extra dep just for it
-`%||%` <- function(a, b) if (is.null(a)) b else a
+`%||%` <- function(a, b) if (is.null(a)) { b } else { a }

--- a/R/audit_ascii.R
+++ b/R/audit_ascii.R
@@ -84,8 +84,8 @@ fix_ascii <- function(pkg = ".",
     dry_run = dry_run
   )
 
-  n_changed <- if (is.null(out)) 0L else sum(out$changed, na.rm = TRUE)
-  verb <- if (isTRUE(dry_run)) "would rewrite" else "rewrote"
+  n_changed <- if (is.null(out)) { 0L } else { sum(out$changed, na.rm = TRUE) }
+  verb <- if (isTRUE(dry_run)) { "would rewrite" } else { "rewrote" }
 
   cli::cli_inform(c(
     "i" = "fix_ascii(): {verb} {n_changed} file{?s} (non-ASCII)."

--- a/R/audit_dataset_doc.R
+++ b/R/audit_dataset_doc.R
@@ -40,7 +40,7 @@ audit_dataset_doc <- function(pkg = ".") {
   }
 
   has_doc <- vapply(names, function(n) {
-    if (!length(r_files)) return(FALSE)
+    if (!length(r_files)) { return(FALSE) }
     # Escape regex metacharacters: dataset names can contain `.` and other
     # symbols that would otherwise mis-match (e.g. `iris.setosa` would match
     # `irisXsetosa`).

--- a/R/audit_tags.R
+++ b/R/audit_tags.R
@@ -115,19 +115,19 @@ audit_tags <- function(pkg = ".") {
   ##
   res_functions <- map(
     .x = blocks,
-    .f = ~ if (class(.x[["object"]])[1] == "function") .x
+    .f = ~ if (class(.x[["object"]])[1] == "function") { .x }
   ) %>%
     compact()
 
   res_package <- map(
     .x = blocks,
-    .f = ~ if (class(.x[["object"]])[1] == "package") .x
+    .f = ~ if (class(.x[["object"]])[1] == "package") { .x }
   ) %>%
     compact()
 
   res_data <- map(
     .x = blocks,
-    .f = ~ if (class(.x[["object"]])[1] == "data") .x
+    .f = ~ if (class(.x[["object"]])[1] == "data") { .x }
   ) %>%
     compact()
 
@@ -136,7 +136,7 @@ audit_tags <- function(pkg = ".") {
   ## because the object class is not "function".
   res_topic_only <- map(
     .x = blocks,
-    .f = ~ if (!(class(.x[["object"]])[1] %in% c("function", "package", "data"))) .x
+    .f = ~ if (!(class(.x[["object"]])[1] %in% c("function", "package", "data"))) { .x }
   ) %>%
     compact()
 
@@ -214,7 +214,7 @@ audit_tags <- function(pkg = ".") {
   ) %>%
     mutate(
       rdname_value = if_else(rdname_value == "", topic, rdname_value),
-      id = if (n() == 0L) integer() else seq_len(n())
+      id = if (n() == 0L) { integer() } else { seq_len(n()) }
     )
 
   # Pull `@return` values from topic-only blocks (`#' @name foo \n NULL`) so
@@ -374,7 +374,7 @@ topic_block_returns <- function(topic_blocks) {
   out <- character()
   for (b in topic_blocks) {
     val <- block_get_return_value(b)
-    if (!nzchar(val)) next
+    if (!nzchar(val)) { next }
     rdname <- roxygen2::block_get_tag_value(b, tag = "rdname")
     if (is.null(rdname) || !nzchar(rdname)) {
       rdname <- b[["object"]][["topic"]]
@@ -382,7 +382,7 @@ topic_block_returns <- function(topic_blocks) {
     if (is.null(rdname) || !nzchar(rdname)) {
       rdname <- roxygen2::block_get_tag_value(b, tag = "name")
     }
-    if (is.null(rdname) || !nzchar(rdname)) next
+    if (is.null(rdname) || !nzchar(rdname)) { next }
     out[rdname] <- val
   }
   out

--- a/R/cran_check_unique.R
+++ b/R/cran_check_unique.R
@@ -16,7 +16,7 @@ cran_check_unique <- function(check_dir, lib_dir, scratch, Ncpus) {
   # check_dir <- file.path(normalizePath("~"), "tmp", "CRAN")
 
   user <- Sys.info()["user"]
-  if (user == "unknown") user <- Sys.getenv("LOGNAME")
+  if (user == "unknown") { user <- Sys.getenv("LOGNAME") }
   # Sys.setenv(
   #   "R_USER_DATA_DIR" =
   #     sprintf("/tmp/check-CRAN-incoming-%s/data", user),

--- a/inst/cran/CRAN_incoming/check_CRAN_incoming.R
+++ b/inst/cran/CRAN_incoming/check_CRAN_incoming.R
@@ -8,7 +8,7 @@ if (!dir.exists(check_dir)) {
 lib_dir <- "../lib/"
 
 user <- Sys.info()["user"]
-if(user == "unknown") user <- Sys.getenv("LOGNAME")
+if(user == "unknown") { user <- Sys.getenv("LOGNAME") }
 Sys.setenv("R_USER_DATA_DIR" =
                sprintf("/tmp/check-CRAN-incoming-%s/data", user),
            "R_USER_CACHE_DIR" =
@@ -37,8 +37,9 @@ Sys.setenv("OPENBLAS_NUM_THREADS" = 1)
 Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false",
            "_R_CHECK_PACKAGE_DEPENDS_IGNORE_MISSING_ENHANCES_" = "true")
 
-if(dir.exists(path <- file.path(normalizePath("~"), "tmp", "scratch")))
-    Sys.setenv("TMPDIR" = path)
+if (dir.exists(path <- file.path(normalizePath("~"), "tmp", "scratch"))) {
+  Sys.setenv("TMPDIR" = path)
+}
 
 check_args <- character()               # No longer "--as-cran" ...
 update_check_dir <- TRUE
@@ -231,10 +232,11 @@ check_env <-
            "_R_CHECK_CRAN_INCOMING_USE_ASPELL_=true",
            "_R_CHECK_CRAN_INCOMING_CHECK_FILE_URIS_=true",
            "_R_CHECK_DATALIST_=true",
-           if(run_CRAN_incoming_feasibility_checks)
-               c("_R_CHECK_LENGTH_1_CONDITION_=package:_R_CHECK_PACKAGE_NAME_,abort,verbose",
-                 ## "_R_CHECK_LENGTH_1_LOGIC2_=package:_R_CHECK_PACKAGE_NAME_,abort,verbose",
-                 character()),
+           if (run_CRAN_incoming_feasibility_checks) {
+             c("_R_CHECK_LENGTH_1_CONDITION_=package:_R_CHECK_PACKAGE_NAME_,abort,verbose",
+               ## "_R_CHECK_LENGTH_1_LOGIC2_=package:_R_CHECK_PACKAGE_NAME_,abort,verbose",
+               character())
+           },
            ## "_R_CHECK_ORPHANED_=true",
            "_R_CHECK_PACKAGE_DEPENDS_IGNORE_MISSING_ENHANCES_=true",
            "_R_CHECK_PACKAGES_USED_CRAN_INCOMING_NOTES_=true",
@@ -259,8 +261,9 @@ check_env <-
            character())
          )
 
-if(!is.null(reverse))
-    reverse$repos <- getOption("repos")["CRAN"]
+if (!is.null(reverse)) {
+  reverse$repos <- getOption("repos")["CRAN"]
+}
 
 pfiles <-
     tools::check_packages_in_dir(check_dir,


### PR DESCRIPTION
## Summary

Internal style alignment so every control-flow body uses braces:

- `if (cond) <expr>` → `if (cond) { <expr> }`
- `for (x in y) <expr>` → `for (x in y) { <expr> }`
- `while (cond) <expr>` → `while (cond) { <expr> }`
- inline else branches and the expression form `n <- if (cond) a else b` → `n <- if (cond) { a } else { b }` are also covered.

## How

AST-targeted script: `parse(file, keep.source = TRUE)` + `utils::getParseData()` to find every `IF`/`FOR`/`WHILE` token whose body expression is not already a `{` block, then surgically rewrite just that span using line/col offsets. Preserves all surrounding formatting (alignment, comments, line breaks).

## Why not `styler`

I tested it. `styler::style_pkg(strict = TRUE)` does enforce braces, but the `wrap_if_else_while_for_function_multi_line_in_curly` transformer is internally coupled to the rest of the tidyverse pipeline (`indent_braces`, `style_line_break_around_curly`, function-arg alignment). Even with every other transformer no-op'd:
- dropping `indent_braces` collapses every block body to column 0
- keeping it pulls in unrelated reformat (function-arg realignment, `c(...)` line break style, etc.)

| Approach | Files touched | Δ lines |
|---|---|---|
| `tidyverse_style(strict = TRUE)` full | 22 | +219 / −125 |
| Targeted styler (no-op all but brace + indent) | 16 | +195 / −143 |
| **AST script (this PR)** | **6** | **+60 / −53** |

The 6 modified files are:
- `R/asciify_helpers.R`, `R/audit_ascii.R`, `R/audit_dataset_doc.R`, `R/audit_tags.R`, `R/cran_check_unique.R`
- `inst/cran/CRAN_incoming/check_CRAN_incoming.R`

Two pre-existing multi-line cases (`asciify_helpers.R:645` and `check_CRAN_incoming.R:234`) needed a manual reflow after wrapping; the other ~50 sites are single-line.

## Test plan

- [x] `parse()` succeeds on every R/ file post-change.
- [x] AST re-scan: 0 unbraced `if`/`for`/`while` bodies remain anywhere under `R/` and `tests/`.
- [x] `devtools::test()` → 297 / 297 PASS.
- [ ] CI green (R-CMD-check on macOS / Ubuntu devel/oldrel/release / Windows, test-coverage, pkgdown).

## Out of scope

- Tidyverse-style alignment of `c(...)`, function args, `=` indentation. If the maintainer wants the package to align on the full tidyverse style guide, a follow-up `styler::style_pkg(strict = TRUE)` PR is the right tool — keeping it separate keeps this PR auditable as "brace rule, nothing else".
- `lintr::brace_linter()` enforcement in CI: also out of scope for this PR; can be added once this is merged so the rule stays applied.