### PR TITLE
fix(check_clean_userspace): survive run_examples() crash + de-brittle test (#93, #54)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # checkhelper (development version)
 
+## `audit_userspace()` / `check_clean_userspace()` robustness
+
+- The `Run examples` step is now wrapped in a `tryCatch()`. When
+  `devtools::run_examples()` fails deep inside `pkgload` (e.g. the
+  `srcrefs[[1L]]: subscript out of bounds` crash on `@examplesIf`
+  examples whose body is fully under `\donttest{}`, on older R +
+  pkgload combos), the audit no longer aborts: it warns, skips the
+  examples slice, and still runs the unit tests / full check /
+  vignettes steps (#93).
+- `tests/testthat/test-check_clean_userspace.R` no longer hardcodes a
+  `nrow == 5/6/11` cascade. It asserts the invariants the function
+  promises (the seeded leaks are caught, every row has the right
+  shape) instead of an exact OS-dependent row count, so the test now
+  runs on every OS (#54).
+
 ## `audit_globals()` / `fix_globals()` skip vignettes / tests / examples
 
 - The internal `R CMD check` triggered by `audit_globals()` and

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,14 @@
   pkgload combos), the audit no longer aborts: it warns, skips the
   examples slice, and still runs the unit tests / full check /
   vignettes steps (#93).
+- On a partial run, the snapshot diff is still computed (rows tagged
+  `source = "Run examples (partial)"`) so files created before the
+  crash do not slip into the next baseline and disappear from the
+  report.
+- The follow-up warning that surfaces files added during examples
+  now lists the files instead of telling the user to "not bother
+  about it" — a real leak written from inside an example would
+  previously have been silently dismissed.
 - `tests/testthat/test-check_clean_userspace.R` no longer hardcodes a
   `nrow == 5/6/11` cascade. It asserts the invariants the function
   promises (the seeded leaks are caught, every row has the right

--- a/R/audit_userspace.R
+++ b/R/audit_userspace.R
@@ -85,10 +85,26 @@ audit_userspace <- function(pkg = ".",
   scratch_shot <- utils::fileSnapshot(scratch_dir, timestamp = scratch_tmpfile, md5sum = TRUE, recursive = TRUE, full.names = TRUE)
 
   cli::cli_rule("Run examples")
-  devtools::run_examples(pkg = pkg, run_donttest = FALSE, run_dontrun = FALSE, fresh = FALSE, document = FALSE)
-  all_files <- what_changed(local_shot, scratch_shot, source = "Run examples", all_files, check_output)
-  if (any(all_files$source == "Run examples")) {
-    warning("One of the 'Run examples' .R file was created to run examples. You should not bother about it")
+  examples_ok <- tryCatch(
+    {
+      devtools::run_examples(pkg = pkg, run_donttest = FALSE, run_dontrun = FALSE, fresh = FALSE, document = FALSE)
+      TRUE
+    },
+    error = function(e) {
+      warning(
+        "Skipping the 'Run examples' step: devtools::run_examples() failed (",
+        conditionMessage(e),
+        "). The remaining steps (full check, vignettes) will still run.",
+        call. = FALSE
+      )
+      FALSE
+    }
+  )
+  if (isTRUE(examples_ok)) {
+    all_files <- what_changed(local_shot, scratch_shot, source = "Run examples", all_files, check_output)
+    if (any(all_files$source == "Run examples")) {
+      warning("One of the 'Run examples' .R file was created to run examples. You should not bother about it")
+    }
   }
 
   local_shot <- utils::fileSnapshot(pkg, timestamp = local_tmpfile, md5sum = TRUE, recursive = TRUE, full.names = TRUE)

--- a/R/audit_userspace.R
+++ b/R/audit_userspace.R
@@ -100,11 +100,26 @@ audit_userspace <- function(pkg = ".",
       FALSE
     }
   )
-  if (isTRUE(examples_ok)) {
-    all_files <- what_changed(local_shot, scratch_shot, source = "Run examples", all_files, check_output)
-    if (any(all_files$source == "Run examples")) {
-      warning("One of the 'Run examples' .R file was created to run examples. You should not bother about it")
-    }
+  # Always diff the snapshots, even on a partial run. Without this,
+  # files created before the crash slipped into the next baseline and
+  # became invisible to the rest of the audit. The source label is
+  # tagged so the report distinguishes a clean run from a partial one.
+  examples_source <- if (isTRUE(examples_ok)) {
+    "Run examples"
+  } else {
+    "Run examples (partial)"
+  }
+  before_examples_rows <- nrow(all_files)
+  all_files <- what_changed(local_shot, scratch_shot, source = examples_source, all_files, check_output)
+  example_leaks <- all_files[
+    seq.int(from = before_examples_rows + 1L, length.out = nrow(all_files) - before_examples_rows),
+  ]
+  if (nrow(example_leaks) > 0L) {
+    warning(
+      "Files surfaced during '", examples_source, "' (review whether each is a real leak or just a helper file):\n",
+      paste0("  - ", example_leaks$file, collapse = "\n"),
+      call. = FALSE
+    )
   }
 
   local_shot <- utils::fileSnapshot(pkg, timestamp = local_tmpfile, md5sum = TRUE, recursive = TRUE, full.names = TRUE)

--- a/dev/SUIVI_ISSUES.md
+++ b/dev/SUIVI_ISSUES.md
@@ -106,15 +106,36 @@ fonctions du paquet (y compris non exportées) deviennent visibles.
   Ajout de `pkgload` aux `Imports`.
 - **Commit** : `fix(find_missing_tags): unload target package on exit (#77)`
 
+### #93 — `Error in srcrefs[[1L]]: subscript out of bounds` sur `@examplesIf`
+Bug environnemental dans `pkgload::run_example()` (ancien R / ancien
+pkgload, exemple `@examplesIf` dont le corps tombe entièrement dans
+`\donttest{}`). Pas reproductible localement avec R 4.5 + pkgload
+récent. Le fix est défensif côté checkhelper plutôt que pourchasser
+l'upstream :
+
+- **Test** : `tests/testthat/test-check_clean_userspace_robust.R` —
+  mocke `devtools::run_examples` pour lever l'erreur et vérifie que
+  `.check_clean_userspace()` continue (warning + tibble valide).
+- **Fix** : `tryCatch()` autour de `devtools::run_examples()` dans
+  `R/audit_userspace.R`, message clair, skip de la passe examples,
+  continuation sur les passes suivantes.
+
+### #54 — Test `check_clean_userspace` brittle / non testable Windows
+La cascade `nrow == 5/6/11` dans `tests/testthat/test-check_clean_userspace.R`
+forçait à `skip_on_os("windows", "mac")` car les artefacts laissés par
+`R CMD check` varient par OS.
+
+- **Refactor** : assertions d'invariants (`nrow >= 4`, `source` et
+  `problem` dans des ensembles connus, les deux fuites seedées sont
+  retrouvées). Plus de `skip_on_os` : le test tourne sur tous les OS.
+
 ## Issues envisagées mais non traitées dans cette passe
 
 | # | Pourquoi pas |
 |---|---|
 | 92 | Demande la repro complète sur `gggenomes` ; je n'ai pas pu reproduire en l'état avec un cas minimal — à creuser sur le repo cité. |
 | 87 | Demande UX (forcer `interactive() == FALSE`) qui touche au lifecycle de RStudio ; à arbitrer avec mainteneur. |
-| 86 | Compatibilité avec roxygen2 dev qui change les `warnings()` en `messages()` ; les tests existants s'adaptent déjà via `if (packageVersion("roxygen2") >= "7.3.0")`. |
-| 93 | `Error in srcrefs[[1L]]` profond, pas de repro minimal sans le paquet `rjd3tramoseats` JVM-dépendant. |
-| 67, 62, 27, 21, 12, 53, 52, 54, 23, 29 | Features ou refactors qui demandent une décision design avant code. |
+| 67, 62, 27, 52, 29 | Features qui demandent une décision design avant code. |
 
 ## CI
 

--- a/tests/testthat/test-check_clean_userspace.R
+++ b/tests/testthat/test-check_clean_userspace.R
@@ -1,19 +1,22 @@
 
 test_that("check_clean_userspace works", {
-  if (!interactive()) {
-    skip_on_os("windows")
-    skip_on_os("mac")
-  }
+  # Invariants instead of an exact row count: R CMD check leaks slightly
+  # different platform-specific artefacts (callr-*, foo.o, symbols.rds,
+  # DESCRIPTION rewrite by document(), ...) so the historical cascade
+  # `nrow == 5/6/11` would either skip whole OSes or break on minor
+  # tooling bumps. We assert the invariants the function actually
+  # promises: the two seeded leaks are caught, every row has the right
+  # shape, and any extra rows live in known noise locations.
 
   path <- suppressWarnings(create_example_pkg())
   dir.create(file.path(path, "tests", "testthat"), recursive = TRUE)
-  # Add a test that let file in the testthat dir
+  # A test that leaks a file in the testthat dir
   cat(
     "cat('#in tests', file = 'in_test.R')",
     file = file.path(path, "tests", "testthat", "test-in_test.R")
   )
 
-  # Add an example that let file in tempdir
+  # A function whose @examples leak a file in tempdir
   cat(
     "#' Function",
     "#' @return 1",
@@ -29,14 +32,11 @@ test_that("check_clean_userspace works", {
     file = file.path(path, "R", "in_example.R")
   )
 
-  # Add a vignette that let file in local ?
-
   suppressWarnings(attachment::att_amend_desc(path = path))
 
   check_output <- tempfile("check_output")
   scratch_dir <- tempfile("dirtmp")
 
-  # debugonce(check_clean_userspace)
   expect_warning(
     expect_message(
       all_files <- check_clean_userspace(pkg = path, check_output = check_output),
@@ -45,62 +45,20 @@ test_that("check_clean_userspace works", {
     "One of the 'Run examples'"
   )
 
-  if (nrow(all_files) == 5) {
-    # In some cases, the check updates the DESCRIPTION file as it run document()
-    expect_equal(all_files$source, c(
-      "Unit tests", "Unit tests", "Run examples", "Run examples",
-      "Full check"
-    ))
-    expect_equal(all_files$problem, c("added", "added", "added", "added", "added"))
-    expect_equal(
-      normalizePath(all_files$where, winslash = "/"),
-      normalizePath(c(path, rep(tempdir(), 4)), winslash = "/")
-    )
-    expect_true(all(grepl("in_test[.]R", all_files$file[1:2])))
-    expect_true(any(grepl("in_example", all_files$file[3:4]))) # One of the two
-    expect_true(any(grepl("DESCRIPTION$", all_files$file[5])))
-  } else if (nrow(all_files) == 6) {
-    # In some cases, the check updates the DESCRIPTION file as it run document()
-    expect_equal(all_files$source, c(
-      "Unit tests", "Unit tests", "Run examples", "Run examples",
-      "Full check", "Full check"
-    ))
-    expect_equal(all_files$problem, c("added", "added", "added", "added", "added", "added"))
-    expect_equal(
-      normalizePath(all_files$where, winslash = "/"),
-      normalizePath(c(path, rep(tempdir(), 5)), winslash = "/")
-    )
-    expect_true(all(grepl("in_test[.]R", all_files$file[1:2])))
-    expect_true(any(grepl("in_example", all_files$file[3:4]))) # One of the two
-    expect_true(any(grepl("DESCRIPTION$", all_files$file[5])))
-    expect_true(any(grepl("symbols[.]rds$", all_files$file[6])))
-  } else if (nrow(all_files) == 11) {
-    expect_equal(all_files$source, c(
-      "Unit tests", "Unit tests", "Run examples", "Run examples",
-      "Full check", "Full check", "Full check", "Full check", "Full check",
-      "Full check", "Full check"
-    ))
-    expect_equal(all_files$problem, c(
-      "added", "added", "added", "added", "added", "added", "added",
-      "added", "added", "added", "added"
-    ))
-    expect_equal(
-      all_files$where,
-      gsub(
-        file.path("/private", c(path, rep(tempdir(), 10)), fsep = ""),
-        pattern = "//",
-        replacement = "/"
-      )
-    )
-    expect_true(all(grepl("in_test[.]R", all_files$file[1:2])))
-    expect_true(any(grepl("in_example", all_files$file[3:4]))) # One of the two
-    expect_true(any(grepl("callr-", all_files$file[5:8])))
-    expect_true(any(grepl("DESCRIPTION$", all_files$file[9])))
-    expect_true(any(grepl("foo[.]o", all_files$file[10])))
-    expect_true(any(grepl("symbols[.]rds", all_files$file[11])))
-  } else {
-    stop("Number of rows is not expected: ", all_files)
-  }
+  expect_s3_class(all_files, "tbl_df")
+  expect_named(all_files, c("source", "problem", "where", "file"))
+  expect_gte(nrow(all_files), 4) # 2x in_test + 2x in_example minimum
+  expect_true(all(all_files$problem %in% c("added", "deleted", "changed")))
+  expect_true(all(all_files$source %in% c(
+    "Unit tests", "Run examples", "Full check", "Build Vignettes",
+    "Tests in check dir"
+  )))
+
+  # The two seeded leaks must be caught, regardless of OS noise:
+  unit_files <- all_files$file[all_files$source == "Unit tests"]
+  example_files <- all_files$file[all_files$source == "Run examples"]
+  expect_true(any(grepl("in_test[.]R", unit_files)))
+  expect_true(any(grepl("in_example", example_files)))
 
   unlink(path, recursive = TRUE)
   unlink(check_output, recursive = TRUE)

--- a/tests/testthat/test-check_clean_userspace.R
+++ b/tests/testthat/test-check_clean_userspace.R
@@ -35,14 +35,13 @@ test_that("check_clean_userspace works", {
   suppressWarnings(attachment::att_amend_desc(path = path))
 
   check_output <- tempfile("check_output")
-  scratch_dir <- tempfile("dirtmp")
 
   expect_warning(
     expect_message(
       all_files <- check_clean_userspace(pkg = path, check_output = check_output),
       "Some files"
     ),
-    "One of the 'Run examples'"
+    "Files surfaced during 'Run examples'"
   )
 
   expect_s3_class(all_files, "tbl_df")
@@ -50,8 +49,8 @@ test_that("check_clean_userspace works", {
   expect_gte(nrow(all_files), 4) # 2x in_test + 2x in_example minimum
   expect_true(all(all_files$problem %in% c("added", "deleted", "changed")))
   expect_true(all(all_files$source %in% c(
-    "Unit tests", "Run examples", "Full check", "Build Vignettes",
-    "Tests in check dir"
+    "Unit tests", "Run examples", "Run examples (partial)",
+    "Full check", "Build Vignettes", "Tests in check dir"
   )))
 
   # The two seeded leaks must be caught, regardless of OS noise:
@@ -62,5 +61,4 @@ test_that("check_clean_userspace works", {
 
   unlink(path, recursive = TRUE)
   unlink(check_output, recursive = TRUE)
-  unlink(scratch_dir, recursive = TRUE)
 })

--- a/tests/testthat/test-check_clean_userspace.R
+++ b/tests/testthat/test-check_clean_userspace.R
@@ -53,9 +53,13 @@ test_that("check_clean_userspace works", {
     "Full check", "Build Vignettes", "Tests in check dir"
   )))
 
-  # The two seeded leaks must be caught, regardless of OS noise:
+  # The two seeded leaks must be caught, regardless of OS noise.
+  # `Run examples` may surface as `Run examples (partial)` if a
+  # platform flake makes devtools::run_examples() abort midway, so
+  # accept both tags when looking for the example leak.
   unit_files <- all_files$file[all_files$source == "Unit tests"]
-  example_files <- all_files$file[all_files$source == "Run examples"]
+  example_files <- all_files$file[all_files$source %in%
+    c("Run examples", "Run examples (partial)")]
   expect_true(any(grepl("in_test[.]R", unit_files)))
   expect_true(any(grepl("in_example", example_files)))
 

--- a/tests/testthat/test-check_clean_userspace_robust.R
+++ b/tests/testthat/test-check_clean_userspace_robust.R
@@ -13,9 +13,9 @@ test_that(".check_clean_userspace() survives a run_examples() crash and continue
   suppressWarnings(attachment::att_amend_desc(path = path))
 
   # Counter env: each fake collaborator records that it was called so
-  # the test can assert continuation (Copilot review on PR #104:
-  # otherwise the test only proves that the function returns a tibble,
-  # not that the rest of the pipeline ran).
+  # the test can assert continuation. Without this counter the test
+  # would only prove that the function returns a tibble, not that the
+  # rest of the pipeline ran after the run_examples crash.
   calls <- new.env(parent = emptyenv())
   calls$test <- 0L
   calls$rcmdcheck <- 0L
@@ -28,9 +28,8 @@ test_that(".check_clean_userspace() survives a run_examples() crash and continue
   }
   # The fake leaks a file into the scratch dir BEFORE throwing, so the
   # snapshot diff afterwards is guaranteed to add at least one row
-  # tagged "Run examples (partial)" — that's what we want to assert
-  # on (Copilot review of #104: otherwise the partial-tag invariant
-  # was short-circuited by the empty-diff escape hatch).
+  # tagged "Run examples (partial)". Without this the partial-tag
+  # invariant would be short-circuited by an empty-diff escape hatch.
   partial_marker <- file.path(tempdir(), "fake_partial_leak.txt")
   fake_run_examples <- function(...) {
     calls$run_examples <- calls$run_examples + 1L
@@ -46,10 +45,9 @@ test_that(".check_clean_userspace() survives a run_examples() crash and continue
     NULL
   }
 
-  # The header contract is "surface a clear warning". Assert it:
-  # expect_warning catches the warning emitted when run_examples()
-  # fails (Copilot review of #104: suppressWarnings/suppressMessages
-  # was burying the contract).
+  # The header contract is "surface a clear warning". Assert it
+  # explicitly with expect_warning() rather than swallowing it
+  # under suppressWarnings / suppressMessages.
   out <- expect_warning(
     suppressMessages(
       testthat::with_mocked_bindings(

--- a/tests/testthat/test-check_clean_userspace_robust.R
+++ b/tests/testthat/test-check_clean_userspace_robust.R
@@ -1,29 +1,73 @@
 # Regression tests for #93: when devtools::run_examples() crashes deep in
 # pkgload (`srcrefs[[1L]]: subscript out of bounds` on @examplesIf with an
 # empty post-strip body, on older R + pkgload), check_clean_userspace()
-# must not abort the whole audit — it must skip the examples step, surface
-# a clear warning, and still run unit tests / full check / vignettes.
+# must not abort the whole audit — it must skip the examples step,
+# surface a clear warning, and STILL run unit tests / full check /
+# vignettes. Plus also call check_clean_userspace internal use the
+# qualified path (checkhelper:::.check_clean_userspace) so the mock
+# stays visible under R CMD check on the installed package.
 
-test_that(".check_clean_userspace() survives a run_examples() crash", {
+test_that(".check_clean_userspace() survives a run_examples() crash and continues", {
   local_tempdir_clean()
   path <- suppressWarnings(create_example_pkg())
   suppressWarnings(attachment::att_amend_desc(path = path))
 
+  # Counter env: each fake collaborator records that it was called so
+  # the test can assert continuation (Copilot review on PR #104:
+  # otherwise the test only proves that the function returns a tibble,
+  # not that the rest of the pipeline ran).
+  calls <- new.env(parent = emptyenv())
+  calls$test <- 0L
+  calls$rcmdcheck <- 0L
+  calls$build_vignettes <- 0L
+  calls$run_examples <- 0L
+
+  fake_test <- function(...) {
+    calls$test <- calls$test + 1L
+    invisible(NULL)
+  }
   fake_run_examples <- function(...) {
+    calls$run_examples <- calls$run_examples + 1L
     stop("subscript out of bounds")
   }
+  fake_rcmdcheck <- function(...) {
+    calls$rcmdcheck <- calls$rcmdcheck + 1L
+    list(notes = character(0), warnings = character(0), errors = character(0))
+  }
+  fake_build_vignettes <- function(...) {
+    calls$build_vignettes <- calls$build_vignettes + 1L
+    NULL
+  }
 
-  expect_warning(
-    out <- testthat::with_mocked_bindings(
-      .check_clean_userspace(pkg = path, check_output = tempfile("check_output")),
+  out <- suppressMessages(suppressWarnings(
+    testthat::with_mocked_bindings(
+      testthat::with_mocked_bindings(
+        checkhelper:::.check_clean_userspace(pkg = path, check_output = tempfile("check_output")),
+        rcmdcheck = fake_rcmdcheck,
+        .package = "rcmdcheck"
+      ),
+      test = fake_test,
       run_examples = fake_run_examples,
+      build_vignettes = fake_build_vignettes,
       .package = "devtools"
-    ),
-    "examples"
-  )
+    )
+  ))
 
   expect_s3_class(out, "tbl_df")
   expect_true(all(c("source", "problem", "where", "file") %in% names(out)))
+
+  # The headline contract: every step downstream of the examples
+  # crash must still have run.
+  expect_gte(calls$run_examples, 1L)
+  expect_gte(calls$rcmdcheck, 1L)
+  expect_gte(calls$build_vignettes, 1L)
+
+  # And the partial-run tag must surface in the report so the user
+  # knows the examples slice was incomplete.
+  expect_true(
+    any(out$source == "Run examples (partial)") || nrow(out) == 0L,
+    info = "either the partial tag is present, or the snapshot diff was empty"
+  )
 
   unlink(path, recursive = TRUE)
 })

--- a/tests/testthat/test-check_clean_userspace_robust.R
+++ b/tests/testthat/test-check_clean_userspace_robust.R
@@ -26,8 +26,15 @@ test_that(".check_clean_userspace() survives a run_examples() crash and continue
     calls$test <- calls$test + 1L
     invisible(NULL)
   }
+  # The fake leaks a file into the scratch dir BEFORE throwing, so the
+  # snapshot diff afterwards is guaranteed to add at least one row
+  # tagged "Run examples (partial)" — that's what we want to assert
+  # on (Copilot review of #104: otherwise the partial-tag invariant
+  # was short-circuited by the empty-diff escape hatch).
+  partial_marker <- file.path(tempdir(), "fake_partial_leak.txt")
   fake_run_examples <- function(...) {
     calls$run_examples <- calls$run_examples + 1L
+    writeLines("partial", partial_marker)
     stop("subscript out of bounds")
   }
   fake_rcmdcheck <- function(...) {
@@ -39,19 +46,26 @@ test_that(".check_clean_userspace() survives a run_examples() crash and continue
     NULL
   }
 
-  out <- suppressMessages(suppressWarnings(
-    testthat::with_mocked_bindings(
+  # The header contract is "surface a clear warning". Assert it:
+  # expect_warning catches the warning emitted when run_examples()
+  # fails (Copilot review of #104: suppressWarnings/suppressMessages
+  # was burying the contract).
+  out <- expect_warning(
+    suppressMessages(
       testthat::with_mocked_bindings(
-        checkhelper:::.check_clean_userspace(pkg = path, check_output = tempfile("check_output")),
-        rcmdcheck = fake_rcmdcheck,
-        .package = "rcmdcheck"
-      ),
-      test = fake_test,
-      run_examples = fake_run_examples,
-      build_vignettes = fake_build_vignettes,
-      .package = "devtools"
-    )
-  ))
+        testthat::with_mocked_bindings(
+          checkhelper:::.check_clean_userspace(pkg = path, check_output = tempfile("check_output")),
+          rcmdcheck = fake_rcmdcheck,
+          .package = "rcmdcheck"
+        ),
+        test = fake_test,
+        run_examples = fake_run_examples,
+        build_vignettes = fake_build_vignettes,
+        .package = "devtools"
+      )
+    ),
+    regexp = "Skipping the 'Run examples' step"
+  )
 
   expect_s3_class(out, "tbl_df")
   expect_true(all(c("source", "problem", "where", "file") %in% names(out)))
@@ -62,12 +76,10 @@ test_that(".check_clean_userspace() survives a run_examples() crash and continue
   expect_gte(calls$rcmdcheck, 1L)
   expect_gte(calls$build_vignettes, 1L)
 
-  # And the partial-run tag must surface in the report so the user
-  # knows the examples slice was incomplete.
-  expect_true(
-    any(out$source == "Run examples (partial)") || nrow(out) == 0L,
-    info = "either the partial tag is present, or the snapshot diff was empty"
-  )
+  # The partial-run tag must surface in the report so the user knows
+  # the examples slice was incomplete. The fake leaked a file before
+  # throwing, so the diff is guaranteed to produce at least one row.
+  expect_true(any(out$source == "Run examples (partial)"))
 
   unlink(path, recursive = TRUE)
 })

--- a/tests/testthat/test-check_clean_userspace_robust.R
+++ b/tests/testthat/test-check_clean_userspace_robust.R
@@ -1,0 +1,29 @@
+# Regression tests for #93: when devtools::run_examples() crashes deep in
+# pkgload (`srcrefs[[1L]]: subscript out of bounds` on @examplesIf with an
+# empty post-strip body, on older R + pkgload), check_clean_userspace()
+# must not abort the whole audit — it must skip the examples step, surface
+# a clear warning, and still run unit tests / full check / vignettes.
+
+test_that(".check_clean_userspace() survives a run_examples() crash", {
+  local_tempdir_clean()
+  path <- suppressWarnings(create_example_pkg())
+  suppressWarnings(attachment::att_amend_desc(path = path))
+
+  fake_run_examples <- function(...) {
+    stop("subscript out of bounds")
+  }
+
+  expect_warning(
+    out <- testthat::with_mocked_bindings(
+      .check_clean_userspace(pkg = path, check_output = tempfile("check_output")),
+      run_examples = fake_run_examples,
+      .package = "devtools"
+    ),
+    "examples"
+  )
+
+  expect_s3_class(out, "tbl_df")
+  expect_true(all(c("source", "problem", "where", "file") %in% names(out)))
+
+  unlink(path, recursive = TRUE)
+})


### PR DESCRIPTION
## Summary

- **#93** : `devtools::run_examples()` peut planter au fond de `pkgload`
  (`srcrefs[[1L]]: subscript out of bounds` sur les exemples `@examplesIf`
  dont le corps tombe entièrement dans `\donttest{}`, sur les vieilles
  combinaisons R + pkgload). L'audit s'arrêtait avant les passes
  *full check* et *vignettes*. `tryCatch()` autour de l'appel : warning
  clair, skip de la passe `Run examples`, continuation des autres.
- **#54** : la cascade `nrow == 5/6/11` dans `test-check_clean_userspace.R`
  imposait `skip_on_os("windows", "mac")` parce que les artefacts laissés
  par `R CMD check` varient par OS. Remplacée par des assertions
  d'invariants (`nrow >= 4`, `source`/`problem` dans des ensembles connus,
  les deux fuites seedées sont retrouvées). Le test tourne maintenant
  sur tous les OS.

## TDD

Test rouge d'abord (`tests/testthat/test-check_clean_userspace_robust.R`)
qui mocke `devtools::run_examples` pour lever l'erreur historique :
- avant le fix : abort propagé à `.check_clean_userspace()` → test FAIL
- après le fix : warning + tibble valide → test PASS

## Test plan

- [x] `devtools::test(filter = "check_clean_userspace_robust")` → PASS
- [x] `devtools::test(filter = "check_clean_userspace$")` → PASS (9 tests, 100s)
- [x] `devtools::test()` complet local → 0 fail
- [ ] CI Windows / macOS pour valider la suppression des `skip_on_os`

Closes #93, closes #54.