### PR TITLE
fix(find_missing_tags, audit_tags): detect missing @return on S3 (#92)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,42 @@
 # checkhelper (development version)
 
+## `audit_userspace()` / `check_clean_userspace()` robustness
+
+- The `Run examples` step is now wrapped in a `tryCatch()`. When
+  `devtools::run_examples()` fails deep inside `pkgload` (e.g. the
+  `srcrefs[[1L]]: subscript out of bounds` crash on `@examplesIf`
+  examples whose body is fully under `\donttest{}`, on older R +
+  pkgload combos), the audit no longer aborts: it warns, skips the
+  examples slice, and still runs the unit tests / full check /
+  vignettes steps (#93).
+- On a partial run, the snapshot diff is still computed (rows tagged
+  `source = "Run examples (partial)"`) so files created before the
+  crash do not slip into the next baseline and disappear from the
+  report.
+- The follow-up warning that surfaces files added during examples
+  now lists the files instead of telling the user to "not bother
+  about it" — a real leak written from inside an example would
+  previously have been silently dismissed.
+- `tests/testthat/test-check_clean_userspace.R` no longer hardcodes a
+  `nrow == 5/6/11` cascade. It asserts the invariants the function
+  promises (the seeded leaks are caught, every row has the right
+  shape) instead of an exact OS-dependent row count, so the test now
+  runs on every OS (#54).
+
+## `audit_globals()` / `fix_globals()` skip vignettes / tests / examples
+
+- The internal `R CMD check` triggered by `audit_globals()` and
+  `fix_globals()` now passes
+  `build_args = "--no-build-vignettes"` and
+  `args = c("--no-manual", "--no-tests", "--no-examples", "--no-vignettes")`.
+  The "no visible binding for global variable" /
+  "no visible global function definition" notes come from R CMD
+  check's static `* checking R code for possible problems` step
+  and never depended on those phases. On a vignette-heavy package
+  this turns a multi-minute wait into a few seconds. The defaults
+  are exposed as `build_args` / `args` arguments to `.get_notes()`
+  so a caller can still opt back in if needed.
+
 ## `audit_tags()` / `find_missing_tags()` now detect S3 cases
 
 - `audit_tags()` and `find_missing_tags()` now flag missing `@return`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,41 +1,18 @@
 # checkhelper (development version)
 
-## `audit_userspace()` / `check_clean_userspace()` robustness
+## `audit_tags()` / `find_missing_tags()` now detect S3 cases
 
-- The `Run examples` step is now wrapped in a `tryCatch()`. When
-  `devtools::run_examples()` fails deep inside `pkgload` (e.g. the
-  `srcrefs[[1L]]: subscript out of bounds` crash on `@examplesIf`
-  examples whose body is fully under `\donttest{}`, on older R +
-  pkgload combos), the audit no longer aborts: it warns, skips the
-  examples slice, and still runs the unit tests / full check /
-  vignettes steps (#93).
-- On a partial run, the snapshot diff is still computed (rows tagged
-  `source = "Run examples (partial)"`) so files created before the
-  crash do not slip into the next baseline and disappear from the
-  report.
-- The follow-up warning that surfaces files added during examples
-  now lists the files instead of telling the user to "not bother
-  about it" — a real leak written from inside an example would
-  previously have been silently dismissed.
-- `tests/testthat/test-check_clean_userspace.R` no longer hardcodes a
-  `nrow == 5/6/11` cascade. It asserts the invariants the function
-  promises (the seeded leaks are caught, every row has the right
-  shape) instead of an exact OS-dependent row count, so the test now
-  runs on every OS (#54).
-
-## `audit_globals()` / `fix_globals()` skip vignettes / tests / examples
-
-- The internal `R CMD check` triggered by `audit_globals()` and
-  `fix_globals()` now passes
-  `build_args = "--no-build-vignettes"` and
-  `args = c("--no-manual", "--no-tests", "--no-examples", "--no-vignettes")`.
-  The "no visible binding for global variable" /
-  "no visible global function definition" notes come from R CMD
-  check's static `* checking R code for possible problems` step
-  and never depended on those phases. On a vignette-heavy package
-  this turns a multi-minute wait into a few seconds. The defaults
-  are exposed as `build_args` / `args` arguments to `.get_notes()`
-  so a caller can still opt back in if needed.
+- `audit_tags()` and `find_missing_tags()` now flag missing `@return`
+  on S3 generics and on S3 methods that have their own Rd file
+  (block carrying a title or `@rdname` / `@describeIn` / `@name`).
+  Previously a strict `class(object)[1] == "function"` filter dropped
+  these blocks silently, so packages like the one reported in #92
+  were told "Good!" while CRAN was still asking for `\value` on
+  generics' Rd files (e.g. `strand_chr.Rd`,
+  `dim.gggenomes_layout.Rd`).
+- Bare-`@export` blocks (no title, no `@rdname` / `@describeIn` /
+  `@name`) are intentionally not flagged: they produce no Rd file and
+  CRAN does not ask for `\value` on them.
 
 ## `create_example_pkg()` covers every audit
 

--- a/R/audit_tags.R
+++ b/R/audit_tags.R
@@ -210,11 +210,23 @@ audit_tags <- function(pkg = ".") {
 
   res_find_rdname_value <- lapply(res_functions, function(x) {
     rdname <- roxygen2::block_get_tag_value(x, tag = "rdname")
-    if (is.null(rdname)) {
-      ""
-    } else {
-      rdname
+    if (!is.null(rdname)) {
+      return(rdname)
     }
+    # `@describeIn target` groups the method with its generic's Rd
+    # file. Without this fallback the method's rdname_value lands on
+    # its own topic, ending up in a singleton group; the method then
+    # looks like it lacks `@return` even though the merged Rd inherits
+    # it from the generic (Copilot review of #105).
+    descin <- roxygen2::block_get_tag_value(x, tag = "describeIn")
+    if (is.null(descin)) {
+      return("")
+    }
+    name <- descin[["name"]]
+    if (is.null(name)) {
+      return("")
+    }
+    as.character(name)
   })
   res_find_return_value <- lapply(res_functions, function(x) {
     block_get_return_value(x)

--- a/R/audit_tags.R
+++ b/R/audit_tags.R
@@ -137,9 +137,10 @@ audit_tags <- function(pkg = ".") {
     # title, no @rdname, no @name) is namespace-only and produces no
     # Rd, so CRAN never asks for `\value` on it — flagging it would be
     # a false positive.
-    # block_has_tags() is vectorised in `tags` and already returns
-    # a scalar logical (`any(block_tags(block) %in% tags)`), so a
-    # single call is enough.
+    # block_has_tags() is vectorised in `tags` and reduces internally
+    # via any(); the surrounding any() here is defensive in case a
+    # future version returns the per-tag vector. Either way a single
+    # call covers all four tag names.
     any(roxygen2::block_has_tags(
       b,
       tags = list("title", "rdname", "describeIn", "name")

--- a/R/audit_tags.R
+++ b/R/audit_tags.R
@@ -217,7 +217,7 @@ audit_tags <- function(pkg = ".") {
     # file. Without this fallback the method's rdname_value lands on
     # its own topic, ending up in a singleton group; the method then
     # looks like it lacks `@return` even though the merged Rd inherits
-    # it from the generic (Copilot review of #105).
+    # it from the generic.
     descin <- roxygen2::block_get_tag_value(x, tag = "describeIn")
     if (is.null(descin)) {
       return("")

--- a/R/audit_tags.R
+++ b/R/audit_tags.R
@@ -137,10 +137,13 @@ audit_tags <- function(pkg = ".") {
     # title, no @rdname, no @name) is namespace-only and produces no
     # Rd, so CRAN never asks for `\value` on it — flagging it would be
     # a false positive.
-    rd_tags <- list("title", "rdname", "describeIn", "name")
-    any(vapply(rd_tags, function(tag) {
-      isTRUE(roxygen2::block_has_tags(b, tags = list(tag)))
-    }, logical(1)))
+    # block_has_tags() is vectorised in `tags` and already returns
+    # a scalar logical (`any(block_tags(block) %in% tags)`), so a
+    # single call is enough.
+    any(roxygen2::block_has_tags(
+      b,
+      tags = list("title", "rdname", "describeIn", "name")
+    ))
   }
 
   res_functions <- map(

--- a/R/audit_tags.R
+++ b/R/audit_tags.R
@@ -113,9 +113,39 @@ audit_tags <- function(pkg = ".") {
   ##
   ## Split blocks into functions or documentations
   ##
+  ## Function-like blocks: plain functions, but also S3 generics and S3
+  ## methods. Pre-#92 the filter was strictly `class[1] == "function"`
+  ## which silently dropped both `s3generic` and `s3method`, so CRAN
+  ## could ask for `\value` on `strand_chr.Rd` (generic) or
+  ## `dim.gggenomes_layout.Rd` (documented method) while
+  ## `find_missing_tags()` still answered "Good!".
+  ##
+  ## We only keep blocks that roxygen2 will actually turn into an Rd
+  ## file, i.e. blocks carrying a title. A bare-`@export` method (no
+  ## title, no description) does not generate its own Rd — it just
+  ## contributes a NAMESPACE entry — so CRAN will not ask for `\value`
+  ## on it and we must not flag it.
+  func_classes <- c("function", "s3generic", "s3method")
+  block_makes_rd <- function(b) {
+    cls <- class(b[["object"]])[1]
+    if (!isTRUE(cls %in% func_classes)) {
+      return(FALSE)
+    }
+    # A block contributes to an Rd file when it has a title (own doc),
+    # or it joins an existing Rd via @rdname / @describeIn, or it sets
+    # the Rd name explicitly via @name. A bare-`@export` block (no
+    # title, no @rdname, no @name) is namespace-only and produces no
+    # Rd, so CRAN never asks for `\value` on it — flagging it would be
+    # a false positive.
+    rd_tags <- list("title", "rdname", "describeIn", "name")
+    any(vapply(rd_tags, function(tag) {
+      isTRUE(roxygen2::block_has_tags(b, tags = list(tag)))
+    }, logical(1)))
+  }
+
   res_functions <- map(
     .x = blocks,
-    .f = ~ if (class(.x[["object"]])[1] == "function") { .x }
+    .f = ~ if (block_makes_rd(.x)) { .x }
   ) %>%
     compact()
 
@@ -136,7 +166,7 @@ audit_tags <- function(pkg = ".") {
   ## because the object class is not "function".
   res_topic_only <- map(
     .x = blocks,
-    .f = ~ if (!(class(.x[["object"]])[1] %in% c("function", "package", "data"))) { .x }
+    .f = ~ if (!(class(.x[["object"]])[1] %in% c(func_classes, "package", "data"))) { .x }
   ) %>%
     compact()
 

--- a/dev/SUIVI_ISSUES.md
+++ b/dev/SUIVI_ISSUES.md
@@ -129,11 +129,30 @@ forçait à `skip_on_os("windows", "mac")` car les artefacts laissés par
   `problem` dans des ensembles connus, les deux fuites seedées sont
   retrouvées). Plus de `skip_on_os` : le test tourne sur tous les OS.
 
+### #92 — `find_missing_tags()` rate les S3 (générique + méthode auto-doc)
+Pour le pattern S3 (`f <- function(...) UseMethod("f")` + `f.classe <-`),
+roxygen2 attribue `class(b$object)[1] = "s3generic"` au générique et
+`"s3method"` à la méthode. Le filtre historique
+`if (class(b$object)[1] == "function")` excluait silencieusement les deux.
+Conséquence : `find_missing_tags()` répond "Good!" alors que CRAN exige
+encore `\value` sur `strand_chr.Rd` (générique) ou
+`dim.gggenomes_layout.Rd` (méthode auto-documentée), comme rapporté pour
+[`gggenomes`](https://github.com/thackl/gggenomes/tree/missing-value-tags).
+
+- **Test** : `tests/testthat/test-s3_missing_value.R` — trois cas :
+  générique sans `@return` (doit être flaggé), méthode avec son propre
+  Rd et sans `@return` (doit être flaggé), méthode `@export` nu sans
+  doc (ne doit **pas** être flaggée — pas de Rd).
+- **Fix** : helper interne `block_makes_rd()` qui élargit le filtre à
+  `c("function", "s3generic", "s3method")` puis ne garde que les blocs
+  qui produisent réellement un fichier Rd (`title` / `rdname` /
+  `describeIn` / `name`). Évite les faux positifs sur les blocs
+  namespace-only (`@export` seul).
+
 ## Issues envisagées mais non traitées dans cette passe
 
 | # | Pourquoi pas |
 |---|---|
-| 92 | Demande la repro complète sur `gggenomes` ; je n'ai pas pu reproduire en l'état avec un cas minimal — à creuser sur le repo cité. |
 | 87 | Demande UX (forcer `interactive() == FALSE`) qui touche au lifecycle de RStudio ; à arbitrer avec mainteneur. |
 | 67, 62, 27, 52, 29 | Features qui demandent une décision design avant code. |
 

--- a/tests/testthat/test-s3_missing_value.R
+++ b/tests/testthat/test-s3_missing_value.R
@@ -1,0 +1,109 @@
+# Regression tests for #92: find_missing_tags() / audit_tags() must report
+# missing @return on S3 generics and on S3 methods that have their own Rd
+# file (block carries a title / description). It must NOT flag methods
+# whose block is just `@export` (no doc → no own Rd, just a NAMESPACE
+# entry merged with the generic's Rd).
+
+local_s3_pkg <- function(envir = parent.frame()) {
+  path <- suppressWarnings(create_example_pkg())
+  unlink(list.files(file.path(path, "R"), full.names = TRUE))
+  unlink(list.files(file.path(path, "man"), full.names = TRUE))
+  withr::defer(unlink(path, recursive = TRUE), envir = envir)
+  path
+}
+
+test_that("S3 generic without @return is flagged as missing", {
+  local_tempdir_clean()
+  path <- local_s3_pkg()
+  cat(
+    "#' Convert strand to character",
+    "#' @param strand strand",
+    "#' @export",
+    "strand_chr <- function(strand) {",
+    "  UseMethod(\"strand_chr\")",
+    "}",
+    "",
+    "#' @export",
+    "strand_chr.character <- function(strand) {",
+    "  strand",
+    "}",
+    sep = "\n",
+    file = file.path(path, "R", "strand.R")
+  )
+  suppressWarnings(attachment::att_amend_desc(path = path))
+
+  res <- .find_missing_tags(package.dir = path)
+
+  flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
+  expect_true("strand_chr" %in% flagged$topic,
+    info = "S3 generic without @return must be flagged"
+  )
+  # The bare `@export` method has no title/description and therefore
+  # does not generate its own Rd file. CRAN won't ask for \value for it.
+  expect_false("strand_chr.character" %in% flagged$topic,
+    info = "Bare-@export S3 method must not be flagged"
+  )
+})
+
+test_that("S3 method with its own doc but no @return is flagged", {
+  local_tempdir_clean()
+  path <- local_s3_pkg()
+  cat(
+    "#' Convert strand to character",
+    "#' @param strand strand",
+    "#' @return character",
+    "#' @export",
+    "strand_chr <- function(strand) {",
+    "  UseMethod(\"strand_chr\")",
+    "}",
+    "",
+    "#' Dim of a layout",
+    "#'",
+    "#' Returns the dimension of the primary table.",
+    "#' @param x layout",
+    "#' @export",
+    "#' @keywords internal",
+    "dim.gggenomes_layout <- function(x) {",
+    "  dim(x)",
+    "}",
+    sep = "\n",
+    file = file.path(path, "R", "strand.R")
+  )
+  # Provide the dummy class so document() doesn't fail loading.
+  cat(
+    "structure(list(), class = \"gggenomes_layout\")",
+    sep = "\n",
+    file = file.path(path, "R", "zzz.R")
+  )
+  suppressWarnings(attachment::att_amend_desc(path = path))
+
+  res <- .find_missing_tags(package.dir = path)
+
+  flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
+  expect_true("dim.gggenomes_layout" %in% flagged$topic,
+    info = "S3 method with own Rd and no @return must be flagged"
+  )
+  expect_false("strand_chr" %in% flagged$topic,
+    info = "S3 generic with @return must stay clean"
+  )
+})
+
+test_that("plain function without @return is still flagged (regression guard)", {
+  local_tempdir_clean()
+  path <- local_s3_pkg()
+  cat(
+    "#' Plain helper",
+    "#' @export",
+    "helper <- function() {",
+    "  1",
+    "}",
+    sep = "\n",
+    file = file.path(path, "R", "helper.R")
+  )
+  suppressWarnings(attachment::att_amend_desc(path = path))
+
+  res <- .find_missing_tags(package.dir = path)
+
+  flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
+  expect_true("helper" %in% flagged$topic)
+})

--- a/tests/testthat/test-s3_missing_value.R
+++ b/tests/testthat/test-s3_missing_value.R
@@ -32,7 +32,7 @@ test_that("S3 generic without @return is flagged as missing", {
   )
   suppressWarnings(attachment::att_amend_desc(path = path))
 
-  res <- suppressMessages(suppressWarnings(.find_missing_tags(package.dir = path)))
+  res <- suppressMessages(suppressWarnings(checkhelper:::.find_missing_tags(package.dir = path)))
 
   flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
   expect_true("strand_chr" %in% flagged$topic,
@@ -77,7 +77,7 @@ test_that("S3 method with its own doc but no @return is flagged", {
   )
   suppressWarnings(attachment::att_amend_desc(path = path))
 
-  res <- suppressMessages(suppressWarnings(.find_missing_tags(package.dir = path)))
+  res <- suppressMessages(suppressWarnings(checkhelper:::.find_missing_tags(package.dir = path)))
 
   flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
   expect_true("dim.gggenomes_layout" %in% flagged$topic,
@@ -102,13 +102,13 @@ test_that("plain function without @return is still flagged (regression guard)", 
   )
   suppressWarnings(attachment::att_amend_desc(path = path))
 
-  res <- suppressMessages(suppressWarnings(.find_missing_tags(package.dir = path)))
+  res <- suppressMessages(suppressWarnings(checkhelper:::.find_missing_tags(package.dir = path)))
 
   flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
   expect_true("helper" %in% flagged$topic)
 })
 
-test_that("S3 method documented with @describeIn inherits @return from the generic (#105 Copilot)", {
+test_that("S3 method documented with @describeIn inherits @return from the generic", {
   local_tempdir_clean()
   path <- local_s3_pkg()
   cat(
@@ -130,7 +130,7 @@ test_that("S3 method documented with @describeIn inherits @return from the gener
   )
   suppressWarnings(attachment::att_amend_desc(path = path))
 
-  res <- suppressMessages(suppressWarnings(.find_missing_tags(package.dir = path)))
+  res <- suppressMessages(suppressWarnings(checkhelper:::.find_missing_tags(package.dir = path)))
 
   flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
   expect_false("foo.character" %in% flagged$topic,

--- a/tests/testthat/test-s3_missing_value.R
+++ b/tests/testthat/test-s3_missing_value.R
@@ -107,3 +107,34 @@ test_that("plain function without @return is still flagged (regression guard)", 
   flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
   expect_true("helper" %in% flagged$topic)
 })
+
+test_that("S3 method documented with @describeIn inherits @return from the generic (#105 Copilot)", {
+  local_tempdir_clean()
+  path <- local_s3_pkg()
+  cat(
+    "#' Generic",
+    "#' @param x x",
+    "#' @return character",
+    "#' @export",
+    "foo <- function(x) {",
+    "  UseMethod(\"foo\")",
+    "}",
+    "",
+    "#' @describeIn foo Method for character",
+    "#' @export",
+    "foo.character <- function(x) {",
+    "  x",
+    "}",
+    sep = "\n",
+    file = file.path(path, "R", "foo.R")
+  )
+  suppressWarnings(attachment::att_amend_desc(path = path))
+
+  res <- suppressMessages(suppressWarnings(.find_missing_tags(package.dir = path)))
+
+  flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
+  expect_false("foo.character" %in% flagged$topic,
+    info = "@describeIn must group the method under the generic so the inherited @return propagates"
+  )
+  expect_false("foo" %in% flagged$topic)
+})

--- a/tests/testthat/test-s3_missing_value.R
+++ b/tests/testthat/test-s3_missing_value.R
@@ -32,7 +32,7 @@ test_that("S3 generic without @return is flagged as missing", {
   )
   suppressWarnings(attachment::att_amend_desc(path = path))
 
-  res <- .find_missing_tags(package.dir = path)
+  res <- suppressMessages(suppressWarnings(.find_missing_tags(package.dir = path)))
 
   flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
   expect_true("strand_chr" %in% flagged$topic,
@@ -77,7 +77,7 @@ test_that("S3 method with its own doc but no @return is flagged", {
   )
   suppressWarnings(attachment::att_amend_desc(path = path))
 
-  res <- .find_missing_tags(package.dir = path)
+  res <- suppressMessages(suppressWarnings(.find_missing_tags(package.dir = path)))
 
   flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
   expect_true("dim.gggenomes_layout" %in% flagged$topic,
@@ -102,7 +102,7 @@ test_that("plain function without @return is still flagged (regression guard)", 
   )
   suppressWarnings(attachment::att_amend_desc(path = path))
 
-  res <- .find_missing_tags(package.dir = path)
+  res <- suppressMessages(suppressWarnings(.find_missing_tags(package.dir = path)))
 
   flagged <- res$functions[res$functions$test_has_export_and_return == "not_ok", ]
   expect_true("helper" %in% flagged$topic)


### PR DESCRIPTION
## Summary

Le filtre historique `class(b\$object)[1] == \"function\"` excluait
silencieusement les blocs où roxygen2 attribue `s3generic` (un
`f <- function(...) UseMethod(\"f\")`) ou `s3method` (un
`f.classe <- function(...)`).

Conséquence rapportée par #92 : `find_missing_tags()` répondait
\"Good!\" alors que CRAN exigeait encore `\value` sur les Rd
correspondants (ex. `strand_chr.Rd`, `dim.gggenomes_layout.Rd` dans
le rapport `gggenomes`).

## Fix

Helper `block_makes_rd()` qui :

1. élargit le filtre à `c(\"function\", \"s3generic\", \"s3method\")` ;
2. ne garde que les blocs que roxygen2 transforme effectivement en
   fichier Rd (présence d'un titre ou d'un `@rdname` / `@describeIn`
   / `@name`).

Les blocs `@export`-only (méthode S3 sans titre) ne génèrent pas leur
propre Rd ; CRAN ne demande pas `\value` dessus, et on ne les flagge
pas (faux positif évité).

## TDD

Test rouge d'abord (`tests/testthat/test-s3_missing_value.R`) :
- générique S3 sans `@return` → doit être flaggé (était silencieux)
- méthode S3 auto-documentée sans `@return` → doit être flaggée
- méthode `@export`-only sans doc → ne doit **pas** être flaggée

Avant le fix : 2 FAIL (les deux cas S3 manqués).
Après le fix : tout vert.

## Test plan

- [x] `devtools::test(filter = \"s3_missing_value\")` → PASS
- [x] `devtools::test(filter = \"tags|missing|returns_alias|inherit_return|rdname_topic|empty_package\")` → PASS (régressions OK)
- [x] `devtools::test()` complet → 0 fail

Closes #92.