### PR TITLE
fix(check_clean_userspace): run examples non-interactively (#87)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
   wrapped in `if (interactive())` are therefore skipped exactly as
   they would be under `R CMD check`, instead of being executed in
   the parent RStudio session (#87).
+- The `<tempdir>/callr` filter in `what_changed()` is anchored with
+  a trailing `/` so it no longer over-matches sibling directories
+  whose name happens to start with `callr` (e.g.
+  `callr2/leaked.txt`, `callright_a_real_leak/...`).
 - The same step is wrapped in a `tryCatch()`. When
   `devtools::run_examples()` fails deep inside `pkgload` (e.g. the
   `srcrefs[[1L]]: subscript out of bounds` crash on `@examplesIf`

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,12 @@
 
 ## `audit_userspace()` / `check_clean_userspace()` robustness
 
-- The `Run examples` step is now wrapped in a `tryCatch()`. When
+- The `Run examples` step now spawns a fresh non-interactive R
+  subprocess (`devtools::run_examples(fresh = TRUE)`). Examples
+  wrapped in `if (interactive())` are therefore skipped exactly as
+  they would be under `R CMD check`, instead of being executed in
+  the parent RStudio session (#87).
+- The same step is wrapped in a `tryCatch()`. When
   `devtools::run_examples()` fails deep inside `pkgload` (e.g. the
   `srcrefs[[1L]]: subscript out of bounds` crash on `@examplesIf`
   examples whose body is fully under `\donttest{}`, on older R +

--- a/R/audit_userspace.R
+++ b/R/audit_userspace.R
@@ -176,7 +176,10 @@ what_changed <- function(local_shot, scratch_shot, source, all_files, check_outp
     "|[.]Rcheck/|",
     normalizePath(file.path(tempdir(), "callr-"), winslash = "/", mustWork = FALSE),
     "|",
-    normalizePath(file.path(tempdir(), "callr"), winslash = "/", mustWork = FALSE),
+    # Anchor with a trailing "/" so we don't accidentally match
+    # sibling directories like `callr2/`, `callrxyz/`, or
+    # `callright_a_real_leak/` that just happen to share the prefix.
+    normalizePath(file.path(tempdir(), "callr"), winslash = "/", mustWork = FALSE), "/",
     "|",
     normalizePath(file.path(tempdir(), "test.*[.](o|c|so)$"), winslash = "/", mustWork = FALSE),
     "|",

--- a/R/audit_userspace.R
+++ b/R/audit_userspace.R
@@ -85,9 +85,14 @@ audit_userspace <- function(pkg = ".",
   scratch_shot <- utils::fileSnapshot(scratch_dir, timestamp = scratch_tmpfile, md5sum = TRUE, recursive = TRUE, full.names = TRUE)
 
   cli::cli_rule("Run examples")
+  # fresh = TRUE spawns a non-interactive callr subprocess so examples
+  # wrapped in `if (interactive())` are skipped exactly as they would be
+  # under R CMD check (#87). With fresh = FALSE the call inherited the
+  # parent session's `interactive()` value and ran example bodies the
+  # user only meant to run in RStudio.
   examples_ok <- tryCatch(
     {
-      devtools::run_examples(pkg = pkg, run_donttest = FALSE, run_dontrun = FALSE, fresh = FALSE, document = FALSE)
+      devtools::run_examples(pkg = pkg, run_donttest = FALSE, run_dontrun = FALSE, fresh = TRUE, document = FALSE)
       TRUE
     },
     error = function(e) {
@@ -170,6 +175,8 @@ what_changed <- function(local_shot, scratch_shot, source, all_files, check_outp
     normalizePath(check_output, winslash = "/"),
     "|[.]Rcheck/|",
     normalizePath(file.path(tempdir(), "callr-"), winslash = "/", mustWork = FALSE),
+    "|",
+    normalizePath(file.path(tempdir(), "callr"), winslash = "/", mustWork = FALSE),
     "|",
     normalizePath(file.path(tempdir(), "test.*[.](o|c|so)$"), winslash = "/", mustWork = FALSE),
     "|",

--- a/dev/SUIVI_ISSUES.md
+++ b/dev/SUIVI_ISSUES.md
@@ -125,16 +125,35 @@ La cascade `nrow == 5/6/11` dans `tests/testthat/test-check_clean_userspace.R`
 forçait à `skip_on_os("windows", "mac")` car les artefacts laissés par
 `R CMD check` varient par OS.
 
-- **Refactor** : assertions d'invariants (`nrow >= 4`, `source` et
-  `problem` dans des ensembles connus, les deux fuites seedées sont
-  retrouvées). Plus de `skip_on_os` : le test tourne sur tous les OS.
+- **Refactor** : assertions d'invariants (`nrow >= 2`, `source` et
+  `problem` dans des ensembles connus, la fuite seedée `in_test.R` est
+  retrouvée). Plus de `skip_on_os` : le test tourne sur tous les OS.
+
+### #87 — Examples `if (interactive())` exécutés par `check_clean_userspace()`
+L'utilisateur lance `check_clean_userspace()` depuis RStudio.
+`devtools::run_examples(fresh = FALSE)` exécutait les examples dans la
+session courante (interactive), donc les blocs `if (interactive()) {...}`
+tournaient — ce qui n'arrive pas sous `R CMD check`.
+
+- **Test** : `tests/testthat/test-check_clean_userspace_interactive.R` —
+  mocke `devtools::run_examples`, capture les arguments, asserte
+  `fresh = TRUE`.
+- **Fix** : `fresh = TRUE` dans l'appel `devtools::run_examples()` dans
+  `R/audit_userspace.R`. Le sous-process callr est non-interactif, donc
+  `interactive()` y vaut `FALSE` exactement comme sous CRAN.
+- **Effet de bord** : les fuites synthétiques d'examples dans
+  `tempfile()` ne sont plus détectées (le sous-process nettoie son
+  tempdir). C'est aligné avec ce que `R CMD check` voit. Le test
+  `check_clean_userspace works` a été simplifié en conséquence (la
+  fuite seedée est désormais celle, réelle, dans `pkg/tests/`).
+  Élargissement de la regex `file.no.problem` pour ignorer aussi le
+  préfixe `callr/` (en plus de `callr-`) introduit par les versions
+  récentes de callr.
 
 ## Issues envisagées mais non traitées dans cette passe
 
 | # | Pourquoi pas |
 |---|---|
-| 92 | Demande la repro complète sur `gggenomes` ; je n'ai pas pu reproduire en l'état avec un cas minimal — à creuser sur le repo cité. |
-| 87 | Demande UX (forcer `interactive() == FALSE`) qui touche au lifecycle de RStudio ; à arbitrer avec mainteneur. |
 | 67, 62, 27, 52, 29 | Features qui demandent une décision design avant code. |
 
 ## CI

--- a/tests/testthat/test-check_clean_userspace.R
+++ b/tests/testthat/test-check_clean_userspace.R
@@ -32,8 +32,10 @@ test_that("check_clean_userspace works", {
   # With fresh = TRUE the example body runs in a callr subprocess
   # whose tempdir is torn down before our post-step snapshot runs, so
   # no example leak is surfaced and the file-list warning never fires
-  # in this fixture. The "Files surfaced during 'Run examples'"
-  # warning is exercised in test-check_clean_userspace_robust.R.
+  # in this fixture. (The "Files surfaced during 'Run examples'"
+  # warning path is not currently asserted on by any test — TODO add
+  # a regression that seeds a real package-tree leak from inside an
+  # example so the warning fires.)
   expect_message(
     all_files <- check_clean_userspace(pkg = path, check_output = check_output),
     "Some files"

--- a/tests/testthat/test-check_clean_userspace.R
+++ b/tests/testthat/test-check_clean_userspace.R
@@ -16,52 +16,43 @@ test_that("check_clean_userspace works", {
     file = file.path(path, "tests", "testthat", "test-in_test.R")
   )
 
-  # A function whose @examples leak a file in tempdir
-  cat(
-    "#' Function",
-    "#' @return 1",
-    "#' @export",
-    "#' @examples",
-    "#' text <- \"in_example\"",
-    "#' file <- tempfile(\"in_example\")",
-    "#' cat(text, file = file)",
-    "in_example <- function() {",
-    "1",
-    "}",
-    sep = "\n",
-    file = file.path(path, "R", "in_example.R")
-  )
-
+  # No synthetic example leak: with `fresh = TRUE` (#87) examples run
+  # in a callr subprocess whose working dir is the `<pkg>.Rcheck` build
+  # tree (filtered out by `what_changed()` as expected check-tree
+  # noise), and whose tempdir is torn down before our post-step
+  # snapshot runs. That mirrors the CRAN-side behaviour: ephemeral
+  # files an example creates in its own session are never seen by
+  # `R CMD check` either. The unit-test seed (`in_test.R` written into
+  # `pkg/tests/testthat/`) remains and covers the real CRAN-policy
+  # case (file added inside the package tree).
   suppressWarnings(attachment::att_amend_desc(path = path))
 
   check_output <- tempfile("check_output")
 
-  expect_warning(
-    expect_message(
-      all_files <- check_clean_userspace(pkg = path, check_output = check_output),
-      "Some files"
-    ),
-    "Files surfaced during 'Run examples'"
+  # With fresh = TRUE the example body runs in a callr subprocess
+  # whose tempdir is torn down before our post-step snapshot runs, so
+  # no example leak is surfaced and the file-list warning never fires
+  # in this fixture. The "Files surfaced during 'Run examples'"
+  # warning is exercised in test-check_clean_userspace_robust.R.
+  expect_message(
+    all_files <- check_clean_userspace(pkg = path, check_output = check_output),
+    "Some files"
   )
 
   expect_s3_class(all_files, "tbl_df")
   expect_named(all_files, c("source", "problem", "where", "file"))
-  expect_gte(nrow(all_files), 4) # 2x in_test + 2x in_example minimum
+  expect_gte(nrow(all_files), 2) # >=2 rows for the in_test.R seed
   expect_true(all(all_files$problem %in% c("added", "deleted", "changed")))
   expect_true(all(all_files$source %in% c(
     "Unit tests", "Run examples", "Run examples (partial)",
     "Full check", "Build Vignettes", "Tests in check dir"
   )))
 
-  # The two seeded leaks must be caught, regardless of OS noise.
-  # `Run examples` may surface as `Run examples (partial)` if a
-  # platform flake makes devtools::run_examples() abort midway, so
-  # accept both tags when looking for the example leak.
+  # With `fresh = TRUE` the example body runs in a subprocess whose
+  # tempdir is torn down before our post-step snapshot runs, so no
+  # example leak is surfaced. Only the unit-test seed survives.
   unit_files <- all_files$file[all_files$source == "Unit tests"]
-  example_files <- all_files$file[all_files$source %in%
-    c("Run examples", "Run examples (partial)")]
   expect_true(any(grepl("in_test[.]R", unit_files)))
-  expect_true(any(grepl("in_example", example_files)))
 
   unlink(path, recursive = TRUE)
   unlink(check_output, recursive = TRUE)

--- a/tests/testthat/test-check_clean_userspace_interactive.R
+++ b/tests/testthat/test-check_clean_userspace_interactive.R
@@ -32,7 +32,11 @@ test_that(".check_clean_userspace() runs examples in a fresh non-interactive R",
   }
   fake_build_vignettes <- function(...) NULL
 
-  suppressWarnings(suppressMessages(try(
+  # No `try(silent = TRUE)`: a real failure inside .check_clean_userspace()
+  # (e.g. attachment::att_amend_desc() blowing up, a mock-binding miss)
+  # must surface as a real error rather than being silently dropped and
+  # then misreported as "fresh != TRUE" (Copilot review of #106).
+  suppressWarnings(suppressMessages(
     testthat::with_mocked_bindings(
       testthat::with_mocked_bindings(
         checkhelper:::.check_clean_userspace(pkg = path, check_output = tempfile("check_output")),
@@ -43,9 +47,8 @@ test_that(".check_clean_userspace() runs examples in a fresh non-interactive R",
       run_examples = fake_run_examples,
       build_vignettes = fake_build_vignettes,
       .package = "devtools"
-    ),
-    silent = TRUE
-  )))
+    )
+  ))
 
   expect_true(isTRUE(captured$args$fresh),
     info = paste(

--- a/tests/testthat/test-check_clean_userspace_interactive.R
+++ b/tests/testthat/test-check_clean_userspace_interactive.R
@@ -1,0 +1,40 @@
+# Regression test for #87: examples wrapped in `if (interactive())`
+# were being executed by .check_clean_userspace() because
+# devtools::run_examples() ran in the *current* R session (which is
+# interactive when launched from RStudio's Cmd+Shift+E shortcut), so
+# `interactive()` returned TRUE inside the example body.
+#
+# The fix is to delegate to a fresh non-interactive subprocess by
+# passing `fresh = TRUE` to devtools::run_examples(). This test
+# captures that contract: it intercepts the call and asserts the flag.
+
+test_that(".check_clean_userspace() runs examples in a fresh non-interactive R", {
+  local_tempdir_clean()
+  path <- suppressWarnings(create_example_pkg())
+  suppressWarnings(attachment::att_amend_desc(path = path))
+
+  captured <- new.env(parent = emptyenv())
+  fake_run_examples <- function(...) {
+    captured$args <- list(...)
+    invisible(NULL)
+  }
+
+  suppressWarnings(suppressMessages(try(
+    testthat::with_mocked_bindings(
+      .check_clean_userspace(pkg = path, check_output = tempfile("check_output")),
+      run_examples = fake_run_examples,
+      .package = "devtools"
+    ),
+    silent = TRUE
+  )))
+
+  expect_true(isTRUE(captured$args$fresh),
+    info = paste(
+      "devtools::run_examples() must be called with fresh = TRUE so",
+      "examples run in a non-interactive subprocess (#87). Got:",
+      paste(deparse(captured$args$fresh), collapse = " ")
+    )
+  )
+
+  unlink(path, recursive = TRUE)
+})

--- a/tests/testthat/test-check_clean_userspace_interactive.R
+++ b/tests/testthat/test-check_clean_userspace_interactive.R
@@ -18,11 +18,30 @@ test_that(".check_clean_userspace() runs examples in a fresh non-interactive R",
     captured$args <- list(...)
     invisible(NULL)
   }
+  # Stub the rest of the heavy pipeline so this contract test stays
+  # cheap and deterministic. Without this, the test was running the
+  # full devtools::test + rcmdcheck::rcmdcheck + devtools::build_vignettes
+  # pipeline against a freshly created example package — tens of seconds
+  # plus CRAN-mirror dependence — only to check one mocked argument
+  # (Copilot review on PR #106). Internal namespace access goes through
+  # checkhelper::: so the mock survives `R CMD check` against the
+  # installed package (Copilot review on PR #107).
+  fake_test <- function(...) invisible(NULL)
+  fake_rcmdcheck <- function(...) {
+    list(notes = character(0), warnings = character(0), errors = character(0))
+  }
+  fake_build_vignettes <- function(...) NULL
 
   suppressWarnings(suppressMessages(try(
     testthat::with_mocked_bindings(
-      .check_clean_userspace(pkg = path, check_output = tempfile("check_output")),
+      testthat::with_mocked_bindings(
+        checkhelper:::.check_clean_userspace(pkg = path, check_output = tempfile("check_output")),
+        rcmdcheck = fake_rcmdcheck,
+        .package = "rcmdcheck"
+      ),
+      test = fake_test,
       run_examples = fake_run_examples,
+      build_vignettes = fake_build_vignettes,
       .package = "devtools"
     ),
     silent = TRUE

--- a/tests/testthat/test-check_clean_userspace_interactive.R
+++ b/tests/testthat/test-check_clean_userspace_interactive.R
@@ -19,13 +19,11 @@ test_that(".check_clean_userspace() runs examples in a fresh non-interactive R",
     invisible(NULL)
   }
   # Stub the rest of the heavy pipeline so this contract test stays
-  # cheap and deterministic. Without this, the test was running the
-  # full devtools::test + rcmdcheck::rcmdcheck + devtools::build_vignettes
-  # pipeline against a freshly created example package — tens of seconds
-  # plus CRAN-mirror dependence — only to check one mocked argument
-  # (Copilot review on PR #106). Internal namespace access goes through
-  # checkhelper::: so the mock survives `R CMD check` against the
-  # installed package (Copilot review on PR #107).
+  # cheap and deterministic: this is a contract test on one mocked
+  # argument, it must not pull in devtools::test, rcmdcheck and
+  # build_vignettes against a freshly created example package.
+  # Internal namespace access goes through checkhelper::: so the
+  # mock survives `R CMD check` against the installed package.
   fake_test <- function(...) invisible(NULL)
   fake_rcmdcheck <- function(...) {
     list(notes = character(0), warnings = character(0), errors = character(0))
@@ -35,7 +33,7 @@ test_that(".check_clean_userspace() runs examples in a fresh non-interactive R",
   # No `try(silent = TRUE)`: a real failure inside .check_clean_userspace()
   # (e.g. attachment::att_amend_desc() blowing up, a mock-binding miss)
   # must surface as a real error rather than being silently dropped and
-  # then misreported as "fresh != TRUE" (Copilot review of #106).
+  # then misreported downstream as "fresh != TRUE".
   suppressWarnings(suppressMessages(
     testthat::with_mocked_bindings(
       testthat::with_mocked_bindings(


### PR DESCRIPTION
## Summary

`devtools::run_examples(fresh = FALSE)` héritait du `interactive()` de
la session parente, donc les blocs `if (interactive())` dans les
examples tournaient quand l'utilisateur appelait
`check_clean_userspace()` depuis RStudio (Cmd+Shift+E ou Console). Ça
divergeait de ce que `R CMD check` fait réellement.

**Fix** : `fresh = TRUE` → callr spawn un sous-process non-interactif,
`interactive()` y vaut `FALSE`. Aligné sur la sémantique CRAN.

## Effet de bord (intentionnel)

Les fuites synthétiques d'examples créées via `tempfile()` ne sont
plus détectées (le sous-process nettoie son tempdir avant qu'on
snapshote). C'est la même chose que ce que voit `R CMD check`, donc
la perte de détection est correcte. Le fixture du test `check_clean_userspace works` est ajusté en
conséquence : on retire la fuite `in_example` synthétique ; la fuite
`in_test.R` (vraie fuite dans `pkg/tests/`) reste pour couvrir la
détection bout-en-bout.

Aussi : élargi la regex `file.no.problem` dans `what_changed()` pour
ignorer le layout `callr/<hash>/` moderne, en plus du préfixe
`callr-*` historique.

## TDD

Test rouge d'abord (`tests/testthat/test-check_clean_userspace_interactive.R`)
qui mocke `devtools::run_examples`, capture les arguments, et asserte
`fresh = TRUE`. Avant le fix : FAIL (`fresh = FALSE`). Après : PASS.

## Stacking

⚠ Cette PR est posée **au-dessus de #104** (`fix/check-clean-userspace-93-54`).
Mergez #104 d'abord, sinon les diffs vont se chevaucher. Une fois #104
mergée, GitHub re-targettera automatiquement cette PR sur `main`.

## Test plan

- [x] `devtools::test(filter = \"check_clean_userspace_interactive\")` → PASS
- [x] `devtools::test(filter = \"check_clean_userspace\")` → PASS (11/11)
- [x] `devtools::test()` complet → 0 fail

Closes #87.