### PR TITLE
perf(audit_globals, fix_globals): skip vignettes / tests / examples in internal R CMD check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # checkhelper (development version)
 
+## `audit_globals()` / `fix_globals()` skip vignettes / tests / examples
+
+- The internal `R CMD check` triggered by `audit_globals()` and
+  `fix_globals()` now passes
+  `build_args = "--no-build-vignettes"` and
+  `args = c("--no-manual", "--no-tests", "--no-examples", "--no-vignettes")`.
+  The "no visible binding for global variable" /
+  "no visible global function definition" notes come from R CMD
+  check's static `* checking R code for possible problems` step
+  and never depended on those phases. On a vignette-heavy package
+  this turns a multi-minute wait into a few seconds. The defaults
+  are exposed as `build_args` / `args` arguments to `.get_notes()`
+  so a caller can still opt back in if needed.
+
 ## `create_example_pkg()` covers every audit
 
 - `create_example_pkg()` gains two opt-in flags so the same one-line

--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -123,9 +123,28 @@ fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
 #' @importFrom dplyr mutate tibble
 #' @importFrom stringr str_extract str_extract_all
 #' @noRd
-.get_notes <- function(path = ".", checks, ...) {
+.get_notes <- function(path = ".", checks,
+                       build_args = "--no-build-vignettes",
+                       args = c(
+                         "--no-manual", "--no-tests",
+                         "--no-examples", "--no-vignettes"
+                       ),
+                       ...) {
+  # The globals notes ("no visible binding for global variable",
+  # "no visible global function definition") come from R CMD check's
+  # static `* checking R code for possible problems` step. They do
+  # not depend on building vignettes, running tests, running
+  # examples, or rendering the manual. Skipping those four phases
+  # turns audit_globals() / fix_globals() from a multi-minute call on
+  # vignette-heavy packages into a few seconds. Caller can still
+  # override via `build_args` / `args` if needed.
   if (missing(checks)) {
-    checks <- rcmdcheck(path = path, ...)
+    checks <- rcmdcheck(
+      path = path,
+      build_args = build_args,
+      args = args,
+      ...
+    )
   }
 
   if (length(checks[["notes"]]) == 0) {

--- a/tests/testthat/test-fix-globals-light-check.R
+++ b/tests/testthat/test-fix-globals-light-check.R
@@ -1,0 +1,59 @@
+# Regression test: fix_globals() / audit_globals() / .get_notes() must
+# call rcmdcheck::rcmdcheck() with the *minimum* args needed to surface
+# the "no visible binding for global variable" / "no visible global
+# function definition" notes.
+#
+# Those notes are emitted by R CMD check's static code analysis pass
+# (`* checking R code for possible problems`). They do NOT depend on
+# building vignettes, running tests, running examples, or rendering
+# the manual. The historical default (`rcmdcheck(path)` with no args)
+# triggered all four heavy phases for nothing — on a package with
+# vignettes, that's minutes of wasted time per call.
+#
+# The contract this test pins down:
+#   - build_args must include "--no-build-vignettes"
+#   - args must include all of "--no-manual", "--no-tests",
+#     "--no-examples", "--no-vignettes"
+
+test_that(".get_notes() runs rcmdcheck with the light flags", {
+  captured <- new.env(parent = emptyenv())
+  fake_rcmdcheck <- function(path, ...) {
+    captured$args <- list(...)
+    list(notes = character(0))
+  }
+
+  testthat::with_mocked_bindings(
+    .get_notes(path = "."),
+    rcmdcheck = fake_rcmdcheck,
+    .package = "checkhelper"
+  )
+
+  expect_true("--no-build-vignettes" %in% captured$args$build_args,
+    info = "build_args must skip vignette building"
+  )
+  for (flag in c("--no-manual", "--no-tests", "--no-examples", "--no-vignettes")) {
+    expect_true(flag %in% captured$args$args,
+      info = sprintf("args must include %s", flag)
+    )
+  }
+})
+
+test_that("user-supplied `checks =` bypasses rcmdcheck entirely", {
+  called <- FALSE
+  fake_rcmdcheck <- function(...) {
+    called <<- TRUE
+    list(notes = character(0))
+  }
+
+  precomputed <- list(notes = character(0))
+
+  testthat::with_mocked_bindings(
+    .get_notes(path = ".", checks = precomputed),
+    rcmdcheck = fake_rcmdcheck,
+    .package = "checkhelper"
+  )
+
+  expect_false(called,
+    info = "supplying `checks` must skip the internal rcmdcheck call"
+  )
+})


### PR DESCRIPTION
## Pourquoi

Les notes \"no visible binding for global variable\" / \"no visible
global function definition\" sont émises par l'étape statique
`* checking R code for possible problems` de `R CMD check`. Elles
**ne dépendent pas** du build des vignettes, ni des tests, ni des
examples, ni du rendu du manuel.

L'appel historique `rcmdcheck(path = path)` (sans args extra)
déclenchait pourtant les quatre phases lourdes pour rien. Sur un
paquet vignette-lourd, un simple `fix_globals(pkg)` lancé seul
pouvait prendre **plusieurs minutes**.

## Fix

`.get_notes()` passe désormais à `rcmdcheck()` :

- `build_args = \"--no-build-vignettes\"`
- `args = c(\"--no-manual\", \"--no-tests\", \"--no-examples\", \"--no-vignettes\")`

Les deux deviennent des paramètres de `.get_notes()` (avec ces
valeurs par défaut), donc un appelant qui veut l'ancien comportement
peut surcharger.

## Qualité de détection

**Inchangée**. La passe statique tourne dans tous les cas. Seul le
wall time chute.

## TDD

Test rouge d'abord (`tests/testthat/test-fix-globals-light-check.R`)
qui mocke `rcmdcheck::rcmdcheck` via `with_mocked_bindings(.package = \"checkhelper\")`
et asserte que :
- `build_args` contient `--no-build-vignettes`
- `args` contient `--no-manual`, `--no-tests`, `--no-examples`, `--no-vignettes`
- `checks =` (pré-calculé) court-circuite toujours `rcmdcheck`

Avant le fix : 5 FAIL (les 5 flags manquants). Après : tout vert.

## Test plan

- [x] `devtools::test(filter = \"fix-globals-light-check\")` → PASS (6/6)
- [x] `devtools::test(filter = \"globals\")` → PASS (9/9, pas de régression)