### PR TITLE
fix(fix_globals): merge with existing R/globals.R instead of overwriting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,42 +1,5 @@
 # checkhelper (development version)
 
-## `audit_userspace()` / `check_clean_userspace()` robustness
-
-- The `Run examples` step is now wrapped in a `tryCatch()`. When
-  `devtools::run_examples()` fails deep inside `pkgload` (e.g. the
-  `srcrefs[[1L]]: subscript out of bounds` crash on `@examplesIf`
-  examples whose body is fully under `\donttest{}`, on older R +
-  pkgload combos), the audit no longer aborts: it warns, skips the
-  examples slice, and still runs the unit tests / full check /
-  vignettes steps (#93).
-- On a partial run, the snapshot diff is still computed (rows tagged
-  `source = "Run examples (partial)"`) so files created before the
-  crash do not slip into the next baseline and disappear from the
-  report.
-- The follow-up warning that surfaces files added during examples
-  now lists the files instead of telling the user to "not bother
-  about it" — a real leak written from inside an example would
-  previously have been silently dismissed.
-- `tests/testthat/test-check_clean_userspace.R` no longer hardcodes a
-  `nrow == 5/6/11` cascade. It asserts the invariants the function
-  promises (the seeded leaks are caught, every row has the right
-  shape) instead of an exact OS-dependent row count, so the test now
-  runs on every OS (#54).
-
-## `audit_globals()` / `fix_globals()` skip vignettes / tests / examples
-
-- The internal `R CMD check` triggered by `audit_globals()` and
-  `fix_globals()` now passes
-  `build_args = "--no-build-vignettes"` and
-  `args = c("--no-manual", "--no-tests", "--no-examples", "--no-vignettes")`.
-  The "no visible binding for global variable" /
-  "no visible global function definition" notes come from R CMD
-  check's static `* checking R code for possible problems` step
-  and never depended on those phases. On a vignette-heavy package
-  this turns a multi-minute wait into a few seconds. The defaults
-  are exposed as `build_args` / `args` arguments to `.get_notes()`
-  so a caller can still opt back in if needed.
-
 ## `fix_globals(write = TRUE)` now merges with the existing `R/globals.R`
 
 - Previously, `fix_globals(write = TRUE)` overwrote `R/globals.R`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,42 @@
 # checkhelper (development version)
 
+## `audit_userspace()` / `check_clean_userspace()` robustness
+
+- The `Run examples` step is now wrapped in a `tryCatch()`. When
+  `devtools::run_examples()` fails deep inside `pkgload` (e.g. the
+  `srcrefs[[1L]]: subscript out of bounds` crash on `@examplesIf`
+  examples whose body is fully under `\donttest{}`, on older R +
+  pkgload combos), the audit no longer aborts: it warns, skips the
+  examples slice, and still runs the unit tests / full check /
+  vignettes steps (#93).
+- On a partial run, the snapshot diff is still computed (rows tagged
+  `source = "Run examples (partial)"`) so files created before the
+  crash do not slip into the next baseline and disappear from the
+  report.
+- The follow-up warning that surfaces files added during examples
+  now lists the files instead of telling the user to "not bother
+  about it" — a real leak written from inside an example would
+  previously have been silently dismissed.
+- `tests/testthat/test-check_clean_userspace.R` no longer hardcodes a
+  `nrow == 5/6/11` cascade. It asserts the invariants the function
+  promises (the seeded leaks are caught, every row has the right
+  shape) instead of an exact OS-dependent row count, so the test now
+  runs on every OS (#54).
+
+## `audit_globals()` / `fix_globals()` skip vignettes / tests / examples
+
+- The internal `R CMD check` triggered by `audit_globals()` and
+  `fix_globals()` now passes
+  `build_args = "--no-build-vignettes"` and
+  `args = c("--no-manual", "--no-tests", "--no-examples", "--no-vignettes")`.
+  The "no visible binding for global variable" /
+  "no visible global function definition" notes come from R CMD
+  check's static `* checking R code for possible problems` step
+  and never depended on those phases. On a vignette-heavy package
+  this turns a multi-minute wait into a few seconds. The defaults
+  are exposed as `build_args` / `args` arguments to `.get_notes()`
+  so a caller can still opt back in if needed.
+
 ## `fix_globals(write = TRUE)` now merges with the existing `R/globals.R`
 
 - Previously, `fix_globals(write = TRUE)` overwrote `R/globals.R`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # checkhelper (development version)
 
+## `fix_globals(write = TRUE)` now merges with the existing `R/globals.R`
+
+- Previously, `fix_globals(write = TRUE)` overwrote `R/globals.R`
+  with a fresh `utils::globalVariables(unique(c(...)))` block. That
+  was unsafe: `R CMD check` already filters out names covered by an
+  existing `globalVariables()` call, so the second time
+  `fix_globals()` ran on a curated package, only the *uncovered*
+  names showed up in the notes - overwriting then erased every
+  previously-declared name and re-flagged it on the next check
+  (circular game).
+- The function now parses the existing `R/globals.R`, extracts the
+  names from any `globalVariables()` / `utils::globalVariables()`
+  calls it finds, and rewrites the file as the deduplicated union
+  of the freshly detected names and the already-declared ones. The
+  preserved block is appended under a `# previously declared:`
+  banner inside the same `unique(c(...))` payload.
+
 ## `audit_userspace()` / `check_clean_userspace()` robustness
 
 - The `Run examples` step is now wrapped in a `tryCatch()`. When
@@ -15,7 +32,7 @@
   report.
 - The follow-up warning that surfaces files added during examples
   now lists the files instead of telling the user to "not bother
-  about it" — a real leak written from inside an example would
+  about it" - a real leak written from inside an example would
   previously have been silently dismissed.
 - `tests/testthat/test-check_clean_userspace.R` no longer hardcodes a
   `nrow == 5/6/11` cascade. It asserts the invariants the function

--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -147,6 +147,14 @@ extract_existing_globals <- function(globals_path) {
     if (!is_globalVariables_call(e)) {
       next
     }
+    # Guard against `utils::globalVariables()` with no arguments
+    # (length(e) == 1 is just the function symbol itself). Without
+    # this guard `e[[2]]` raises subscript out of bounds and aborts
+    # the whole `fix_globals(write = TRUE)` pass on a degenerate
+    # but otherwise legal `globals.R`.
+    if (length(e) < 2L) {
+      next
+    }
     out <- c(out, collect_string_literals(e[[2]]))
   }
   unique(out)
@@ -158,7 +166,7 @@ extract_existing_globals <- function(globals_path) {
 #' file's contents — the historic `eval(arg, envir = safe_env)` ran
 #' under `baseenv()` (which exposes `system()`, `library()`, `file()`,
 #' …), so a crafted `globals.R` could execute arbitrary code at
-#' `fix_globals(write = TRUE)` time (Copilot review of #108).
+#' `fix_globals(write = TRUE)` time.
 #'
 #' Symbols, numerics, logicals, `NULL`, and arbitrary calls
 #' (`system(...)`, `c(...)`, `unique(...)`) are walked through but

--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -56,8 +56,10 @@ audit_globals <- function(pkg = ".", checks = NULL) {
 #' `R/globals.R`. Wraps [print_globals()].
 #'
 #' @param pkg Path to the package.
-#' @param write If `TRUE`, **overwrite** `<pkg>/R/globals.R` with a
-#'   single `globalVariables(...)` call. Default `FALSE` (print the
+#' @param write If `TRUE`, write a single `globalVariables(...)` call
+#'   to `<pkg>/R/globals.R`, **merging** with whatever names that file
+#'   already declares (the freshly detected names are added on top of
+#'   the existing ones, deduplicated). Default `FALSE` (print the
 #'   block to the console for manual paste).
 #' @param checks Optional. A pre-computed [rcmdcheck::rcmdcheck()] result
 #'   (a list with at least a `notes` element). When supplied, `fix_globals()`
@@ -194,6 +196,22 @@ merge_globals_block <- function(fresh_block, preserved) {
     "# previously declared:\n",
     paste0("\"", preserved, "\"", collapse = ", ")
   )
+  # When R CMD check surfaces only function notes, the fresh block's
+  # `c()` body is empty (`utils::globalVariables(unique(c(\n\n)))`).
+  # Naively prepending a `,` then injecting yields `c(, "a", "b")`,
+  # which parses but errors at eval with "argument 1 is empty".
+  # Detect the empty-body shape and rebuild from scratch.
+  is_empty_body <- grepl(
+    "utils::globalVariables\\(unique\\(c\\(\\s*\\n\\s*\\n\\s*\\)\\)\\)$",
+    fresh_block
+  )
+  if (is_empty_body) {
+    return(paste0(
+      "utils::globalVariables(unique(c(\n",
+      preserved_chunk,
+      "\n)))"
+    ))
+  }
   # Inject just before the final closing `)))`.
   sub(
     "\n\\)\\)\\)$",

--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -142,19 +142,40 @@ extract_existing_globals <- function(globals_path) {
     return(character(0))
   }
   out <- character(0)
-  safe_env <- new.env(parent = baseenv())
   for (i in seq_along(exprs)) {
     e <- exprs[[i]]
     if (!is_globalVariables_call(e)) {
       next
     }
-    arg <- e[[2]]
-    vals <- tryCatch(eval(arg, envir = safe_env), error = function(e2) NULL)
-    if (is.character(vals)) {
-      out <- c(out, vals)
-    }
+    out <- c(out, collect_string_literals(e[[2]]))
   }
   unique(out)
+}
+
+#' Recursively collect every character-literal leaf of an unevaluated R
+#' expression. Used by `extract_existing_globals()` to read the names
+#' from an existing `R/globals.R` without ever calling `eval()` on the
+#' file's contents — the historic `eval(arg, envir = safe_env)` ran
+#' under `baseenv()` (which exposes `system()`, `library()`, `file()`,
+#' …), so a crafted `globals.R` could execute arbitrary code at
+#' `fix_globals(write = TRUE)` time (Copilot review of #108).
+#'
+#' Symbols, numerics, logicals, `NULL`, and arbitrary calls
+#' (`system(...)`, `c(...)`, `unique(...)`) are walked through but
+#' never evaluated; only quoted character literals are returned.
+#' @noRd
+collect_string_literals <- function(expr) {
+  if (is.character(expr) && length(expr) >= 1L) {
+    return(as.character(expr))
+  }
+  if (is.call(expr)) {
+    out <- character(0)
+    for (i in seq_along(expr)) {
+      out <- c(out, collect_string_literals(expr[[i]]))
+    }
+    return(out)
+  }
+  character(0)
 }
 
 #' TRUE when `e` is a call to `globalVariables()` or

--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -106,9 +106,18 @@ fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
     dir.create(dirname(globals_path), recursive = TRUE)
   }
 
-  writeLines(printed[["liste_globals_code"]], globals_path)
+  # Merge with whatever the file already declared. R CMD check filters
+  # out names already covered by an existing globalVariables() call,
+  # so by the time fix_globals() runs the second time, the new notes
+  # only list *uncovered* names. Overwriting would erase the curated
+  # set and re-flag those names on the very next check — a circular
+  # game the user can never win.
+  preserved <- extract_existing_globals(globals_path)
+  merged_block <- merge_globals_block(printed[["liste_globals_code"]], preserved)
+
+  writeLines(merged_block, globals_path)
   cli::cli_inform(c(
-    "v" = "fix_globals(): wrote globalVariables block to {.file {globals_path}}."
+    "v" = "fix_globals(): wrote globalVariables block to {.file {globals_path}} (merged with {length(preserved)} previously declared name{?s})."
   ))
 
   invisible(globals_path)
@@ -116,6 +125,82 @@ fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
 
 
 # Internal implementations ---------------------------------------------------
+
+#' Extract the names already declared by `globalVariables()` calls in
+#' an existing `R/globals.R`. Returns `character(0)` when the file
+#' doesn't exist or doesn't parse.
+#'
+#' @noRd
+extract_existing_globals <- function(globals_path) {
+  if (!file.exists(globals_path)) {
+    return(character(0))
+  }
+  exprs <- tryCatch(parse(file = globals_path), error = function(e) NULL)
+  if (is.null(exprs)) {
+    return(character(0))
+  }
+  out <- character(0)
+  safe_env <- new.env(parent = baseenv())
+  for (i in seq_along(exprs)) {
+    e <- exprs[[i]]
+    if (!is_globalVariables_call(e)) {
+      next
+    }
+    arg <- e[[2]]
+    vals <- tryCatch(eval(arg, envir = safe_env), error = function(e2) NULL)
+    if (is.character(vals)) {
+      out <- c(out, vals)
+    }
+  }
+  unique(out)
+}
+
+#' TRUE when `e` is a call to `globalVariables()` or
+#' `utils::globalVariables()`.
+#' @noRd
+is_globalVariables_call <- function(e) {
+  if (!is.call(e)) {
+    return(FALSE)
+  }
+  fn <- e[[1]]
+  if (is.name(fn) && identical(fn, as.name("globalVariables"))) {
+    return(TRUE)
+  }
+  if (is.call(fn) && length(fn) == 3 &&
+        identical(fn[[1]], as.name("::")) &&
+        identical(fn[[2]], as.name("utils")) &&
+        identical(fn[[3]], as.name("globalVariables"))) {
+    return(TRUE)
+  }
+  FALSE
+}
+
+#' Inject the previously-declared names into the freshly generated
+#' `globalVariables(unique(c(...)))` block so that the rewrite is a
+#' superset of the existing declarations.
+#'
+#' @param fresh_block character(1), the block produced by
+#'   `.print_globals()$liste_globals_code`. Always wrapped in
+#'   `unique(c(...))` so duplicates are harmless.
+#' @param preserved character vector of names parsed from the
+#'   existing `globals.R` (may be empty).
+#' @noRd
+merge_globals_block <- function(fresh_block, preserved) {
+  if (length(preserved) == 0L) {
+    return(fresh_block)
+  }
+  preserved <- sort(unique(preserved))
+  preserved_chunk <- paste0(
+    "# previously declared:\n",
+    paste0("\"", preserved, "\"", collapse = ", ")
+  )
+  # Inject just before the final closing `)))`.
+  sub(
+    "\n\\)\\)\\)$",
+    paste0(", \n", preserved_chunk, "\n)))"),
+    fresh_block
+  )
+}
 
 #' List notes from check and identify global variables.
 #'

--- a/tests/testthat/test-fix-globals-merge.R
+++ b/tests/testthat/test-fix-globals-merge.R
@@ -81,13 +81,13 @@ test_that("fix_globals(write = TRUE) deduplicates across old / new", {
 })
 
 test_that("fix_globals(write = TRUE) handles empty fresh + non-empty preserved", {
-  # Regression for the bug Copilot flagged on PR #108: when R CMD check
-  # surfaces only function notes (no `is_global_variable` rows), the
-  # freshly built `globalVariables(unique(c(\n\n)))` body is empty.
-  # The previous merge injected a leading `,` before the preserved
-  # chunk, producing `c(, \n# ...\n"a")` which parses but errors at
-  # eval time with "argument 1 is empty". The output must always be
-  # both parseable AND evaluable (sourcing the file must not throw).
+  # When R CMD check surfaces only function notes (no
+  # `is_global_variable` rows), the freshly built
+  # `globalVariables(unique(c(\n\n)))` body is empty. A naive merge
+  # would inject a leading `,` before the preserved chunk, producing
+  # `c(, \n# ...\n"a")` which parses but errors at eval time with
+  # "argument 1 is empty". The output must always be both parseable
+  # AND evaluable (sourcing the file must not throw).
   path <- local_pkg_with_globals()
   globals_path <- file.path(path, "R", "globals.R")
   writeLines(
@@ -133,24 +133,26 @@ test_that("fix_globals(write = TRUE) handles empty fresh + non-empty preserved",
   )
 })
 
-test_that("extract_existing_globals does NOT execute side effects from globals.R (RCE guard, Copilot #108)", {
-  # Sanity guard against the security finding Copilot raised on PR
-  # #108: previously extract_existing_globals() ran
-  # `eval(arg, envir = safe_env)` where `safe_env`'s parent was
-  # `baseenv()`. baseenv() exposes `system()`, `library()`, `file()`,
-  # so a malicious or accidentally clever R/globals.R could execute
-  # arbitrary code at fix_globals(write = TRUE) time. The fix walks
-  # the AST and collects only character literals — the side effect
-  # must never fire, even though the file contains a perfectly
-  # evaluable call.
+test_that("extract_existing_globals does NOT execute side effects from globals.R (RCE guard)", {
+  # Sanity guard against a known RCE shape: if extract_existing_globals
+  # ever fell back to `eval()` under `baseenv()` (which exposes
+  # `file.create`, `system`, `library`, `file`, ...), a malicious or
+  # accidentally clever `R/globals.R` could execute arbitrary code at
+  # `fix_globals(write = TRUE)` time. The current implementation walks
+  # the AST and collects only character literals; the side effect must
+  # never fire even though the embedded call is perfectly evaluable.
+  #
+  # Use `file.create()` (cross-platform: Linux / macOS / Windows)
+  # rather than `system("touch ...")`, which silently no-ops on
+  # Windows and would make the test toothless on that platform.
   marker <- tempfile("rce_marker_")
   expect_false(file.exists(marker))
 
   globals_path <- tempfile(fileext = ".R")
   writeLines(
     sprintf(
-      'utils::globalVariables(c(system("touch %s", intern = TRUE), "real_var"))',
-      marker
+      'utils::globalVariables(c(if (file.create(%s)) "leaked" else "ok", "real_var"))',
+      shQuote(marker)
     ),
     globals_path
   )
@@ -165,6 +167,23 @@ test_that("extract_existing_globals does NOT execute side effects from globals.R
     info = "extract_existing_globals must never execute calls inside globals.R"
   )
   expect_true("real_var" %in% result)
+})
+
+test_that("extract_existing_globals tolerates `globalVariables()` with no arguments", {
+  # Degenerate but legal call shape: a `globals.R` containing just
+  # `utils::globalVariables()` (no args) used to crash the extractor
+  # with `subscript out of bounds` on `e[[2]]`, aborting the entire
+  # `fix_globals(write = TRUE)` pass. The walker now arity-checks the
+  # call before dereferencing.
+  globals_path <- tempfile(fileext = ".R")
+  writeLines(
+    'utils::globalVariables()',
+    globals_path
+  )
+  on.exit(unlink(globals_path), add = TRUE)
+
+  expect_no_error(result <- extract_existing_globals(globals_path))
+  expect_equal(result, character(0))
 })
 
 test_that("fix_globals(write = TRUE) handles the no-existing-file case", {

--- a/tests/testthat/test-fix-globals-merge.R
+++ b/tests/testthat/test-fix-globals-merge.R
@@ -161,7 +161,7 @@ test_that("extract_existing_globals does NOT execute side effects from globals.R
     unlink(marker)
   }, add = TRUE)
 
-  result <- extract_existing_globals(globals_path)
+  result <- checkhelper:::extract_existing_globals(globals_path)
 
   expect_false(file.exists(marker),
     info = "extract_existing_globals must never execute calls inside globals.R"
@@ -182,7 +182,7 @@ test_that("extract_existing_globals tolerates `globalVariables()` with no argume
   )
   on.exit(unlink(globals_path), add = TRUE)
 
-  expect_no_error(result <- extract_existing_globals(globals_path))
+  expect_no_error(result <- checkhelper:::extract_existing_globals(globals_path))
   expect_equal(result, character(0))
 })
 

--- a/tests/testthat/test-fix-globals-merge.R
+++ b/tests/testthat/test-fix-globals-merge.R
@@ -133,6 +133,40 @@ test_that("fix_globals(write = TRUE) handles empty fresh + non-empty preserved",
   )
 })
 
+test_that("extract_existing_globals does NOT execute side effects from globals.R (RCE guard, Copilot #108)", {
+  # Sanity guard against the security finding Copilot raised on PR
+  # #108: previously extract_existing_globals() ran
+  # `eval(arg, envir = safe_env)` where `safe_env`'s parent was
+  # `baseenv()`. baseenv() exposes `system()`, `library()`, `file()`,
+  # so a malicious or accidentally clever R/globals.R could execute
+  # arbitrary code at fix_globals(write = TRUE) time. The fix walks
+  # the AST and collects only character literals — the side effect
+  # must never fire, even though the file contains a perfectly
+  # evaluable call.
+  marker <- tempfile("rce_marker_")
+  expect_false(file.exists(marker))
+
+  globals_path <- tempfile(fileext = ".R")
+  writeLines(
+    sprintf(
+      'utils::globalVariables(c(system("touch %s", intern = TRUE), "real_var"))',
+      marker
+    ),
+    globals_path
+  )
+  on.exit({
+    unlink(globals_path)
+    unlink(marker)
+  }, add = TRUE)
+
+  result <- extract_existing_globals(globals_path)
+
+  expect_false(file.exists(marker),
+    info = "extract_existing_globals must never execute calls inside globals.R"
+  )
+  expect_true("real_var" %in% result)
+})
+
 test_that("fix_globals(write = TRUE) handles the no-existing-file case", {
   path <- local_pkg_with_globals()
   globals_path <- file.path(path, "R", "globals.R")

--- a/tests/testthat/test-fix-globals-merge.R
+++ b/tests/testthat/test-fix-globals-merge.R
@@ -1,0 +1,96 @@
+# Regression test: fix_globals(write = TRUE) must merge new globals
+# with what's already declared in R/globals.R, not overwrite.
+#
+# Why: R CMD check filters out names already covered by an existing
+# globalVariables() call. So the second time fix_globals() runs on a
+# package that already has a curated globals.R, the notes only list
+# the *new* uncovered names — overwriting the file would erase the
+# previously-declared names and re-flag them on the next check.
+# That's a circular game the user can't win.
+
+local_pkg_with_globals <- function(envir = parent.frame()) {
+  path <- tempfile("pkg-globals-")
+  dir.create(file.path(path, "R"), recursive = TRUE)
+  withr::defer(unlink(path, recursive = TRUE), envir = envir)
+  path
+}
+
+fake_globals <- function(vars) {
+  list(
+    globalVariables = tibble::tibble(
+      fun = rep("my_fun", length(vars)),
+      variable = vars
+    ),
+    functions = tibble::tibble(
+      fun = character(0),
+      variable = character(0),
+      proposed = character(0)
+    )
+  )
+}
+
+test_that("fix_globals(write = TRUE) preserves previously declared globals", {
+  path <- local_pkg_with_globals()
+  globals_path <- file.path(path, "R", "globals.R")
+  writeLines(
+    'utils::globalVariables(c("preserved_old_var", "another_old_var"))',
+    globals_path
+  )
+
+  testthat::with_mocked_bindings(
+    fix_globals(pkg = path, write = TRUE),
+    .get_no_visible = function(...) fake_globals(c("brand_new_var")),
+    .package = "checkhelper"
+  )
+
+  written <- paste(readLines(globals_path), collapse = "\n")
+
+  expect_match(written, "brand_new_var", info = "new global must be present")
+  expect_match(written, "preserved_old_var",
+    info = "previously declared global must survive the rewrite"
+  )
+  expect_match(written, "another_old_var",
+    info = "every previously declared global must survive"
+  )
+})
+
+test_that("fix_globals(write = TRUE) deduplicates across old / new", {
+  path <- local_pkg_with_globals()
+  globals_path <- file.path(path, "R", "globals.R")
+  writeLines(
+    'utils::globalVariables(c("shared", "old_only"))',
+    globals_path
+  )
+
+  testthat::with_mocked_bindings(
+    fix_globals(pkg = path, write = TRUE),
+    .get_no_visible = function(...) fake_globals(c("shared", "new_only")),
+    .package = "checkhelper"
+  )
+
+  # Parse what we wrote and compare to the expected union.
+  exprs <- parse(file = globals_path)
+  collected <- character(0)
+  for (i in seq_along(exprs)) {
+    if (is.call(exprs[[i]])) {
+      collected <- c(collected, eval(exprs[[i]][[2]]))
+    }
+  }
+
+  expect_setequal(collected, c("shared", "old_only", "new_only"))
+})
+
+test_that("fix_globals(write = TRUE) handles the no-existing-file case", {
+  path <- local_pkg_with_globals()
+  globals_path <- file.path(path, "R", "globals.R")
+  expect_false(file.exists(globals_path))
+
+  testthat::with_mocked_bindings(
+    fix_globals(pkg = path, write = TRUE),
+    .get_no_visible = function(...) fake_globals(c("first_var")),
+    .package = "checkhelper"
+  )
+
+  expect_true(file.exists(globals_path))
+  expect_match(paste(readLines(globals_path), collapse = "\n"), "first_var")
+})

--- a/tests/testthat/test-fix-globals-merge.R
+++ b/tests/testthat/test-fix-globals-merge.R
@@ -80,6 +80,59 @@ test_that("fix_globals(write = TRUE) deduplicates across old / new", {
   expect_setequal(collected, c("shared", "old_only", "new_only"))
 })
 
+test_that("fix_globals(write = TRUE) handles empty fresh + non-empty preserved", {
+  # Regression for the bug Copilot flagged on PR #108: when R CMD check
+  # surfaces only function notes (no `is_global_variable` rows), the
+  # freshly built `globalVariables(unique(c(\n\n)))` body is empty.
+  # The previous merge injected a leading `,` before the preserved
+  # chunk, producing `c(, \n# ...\n"a")` which parses but errors at
+  # eval time with "argument 1 is empty". The output must always be
+  # both parseable AND evaluable (sourcing the file must not throw).
+  path <- local_pkg_with_globals()
+  globals_path <- file.path(path, "R", "globals.R")
+  writeLines(
+    'utils::globalVariables(c("preserved_only_var"))',
+    globals_path
+  )
+
+  empty_globals <- list(
+    globalVariables = tibble::tibble(
+      fun = character(0), variable = character(0)
+    ),
+    functions = tibble::tibble(
+      fun = "fn", variable = "some_fn", proposed = NA_character_
+    )
+  )
+
+  testthat::with_mocked_bindings(
+    fix_globals(pkg = path, write = TRUE),
+    .get_no_visible = function(...) empty_globals,
+    .package = "checkhelper"
+  )
+
+  # The file must parse, and the c(...) argument inside the
+  # globalVariables() call must evaluate to a character vector
+  # containing the preserved name. The previous bug produced
+  # `c(, "preserved_only_var")` which parses but fails at eval
+  # with "argument 1 is empty".
+  expect_silent(parse(file = globals_path))
+  exprs <- parse(file = globals_path)
+  found <- character(0)
+  for (i in seq_along(exprs)) {
+    e <- exprs[[i]]
+    if (is.call(e) && length(e) >= 2L) {
+      vals <- eval(e[[2]], envir = baseenv())
+      expect_true(is.character(vals),
+        info = "the c(...) argument must evaluate to a character vector"
+      )
+      found <- c(found, vals)
+    }
+  }
+  expect_true("preserved_only_var" %in% found,
+    info = "the preserved name must round-trip through write+parse"
+  )
+})
+
 test_that("fix_globals(write = TRUE) handles the no-existing-file case", {
   path <- local_pkg_with_globals()
   globals_path <- file.path(path, "R", "globals.R")


### PR DESCRIPTION
## Pourquoi

`fix_globals(write = TRUE)` écrasait `R/globals.R` avec un bloc
`utils::globalVariables(unique(c(...)))` régénéré à partir des seules
notes du dernier `R CMD check`.

Or `R CMD check` filtre déjà les noms couverts par un
`globalVariables()` existant. La 2ᵉ fois où l'utilisateur lance
`fix_globals()` sur un paquet déjà nettoyé, les notes ne listent que
les noms **non encore couverts**. Réécrire avec ces seuls noms efface
tout le set précédemment curé, et au prochain check les anciens noms
reviennent — **raisonnement circulaire**, l'utilisateur n'en sort
jamais.

## Fix

Avant l'écriture, on parse `R/globals.R` existant, on extrait les
noms de chaque appel `globalVariables()` / `utils::globalVariables()`
trouvé, et on réécrit le fichier comme l'**union dédupliquée** des
noms fraîchement détectés et des noms déjà déclarés. Le bloc
préservé est injecté sous une bannière `# previously declared:` à
l'intérieur du même `unique(c(...))`, donc les doublons sont
absorbés naturellement.

Deux helpers internes :

- `extract_existing_globals(globals_path)` — parse le fichier,
  retourne les vecteurs `character` de chaque appel
  `globalVariables()` (rien si le fichier est absent ou ne parse pas).
- `merge_globals_block(fresh_block, preserved)` — injecte les noms
  préservés juste avant le `)))` de fermeture.

## TDD

Test rouge d'abord (`tests/testthat/test-fix-globals-merge.R`) :

1. **Préservation** : un `globals.R` existant avec
   `c(\"preserved_old_var\", \"another_old_var\")` doit conserver les
   deux après un `fix_globals()` qui détecte un nouveau
   `\"brand_new_var\"`.
2. **Déduplication** : si un nom est dans les deux côtés (old + new),
   il n'apparaît qu'une fois dans le fichier final (sémantique union).
3. **Fichier inexistant** : comportement inchangé, la création
   classique tient.

Avant le fix : 3 FAIL (le merge n'existait pas). Après : 7 PASS.

`.get_no_visible` est mocké via `with_mocked_bindings` pour garder le
test déterministe et rapide (pas de vrai `R CMD check`).

## Test plan

- [x] `devtools::test(filter = \"fix-globals-merge\")` → 7/7
- [x] `devtools::test(filter = \"globals\")` → pas de régression