### PR TITLE
test: qualify .get_notes() with checkhelper::: in light-check mock (Copilot review on #107)

### DIFF
--- a/tests/testthat/test-fix-globals-light-check.R
+++ b/tests/testthat/test-fix-globals-light-check.R
@@ -23,7 +23,7 @@ test_that(".get_notes() runs rcmdcheck with the light flags", {
   }
 
   testthat::with_mocked_bindings(
-    .get_notes(path = "."),
+    checkhelper:::.get_notes(path = "."),
     rcmdcheck = fake_rcmdcheck,
     .package = "checkhelper"
   )
@@ -48,7 +48,7 @@ test_that("user-supplied `checks =` bypasses rcmdcheck entirely", {
   precomputed <- list(notes = character(0))
 
   testthat::with_mocked_bindings(
-    .get_notes(path = ".", checks = precomputed),
+    checkhelper:::.get_notes(path = ".", checks = precomputed),
     rcmdcheck = fake_rcmdcheck,
     .package = "checkhelper"
   )


### PR DESCRIPTION
## Pourquoi

Suivi du retour Copilot sur la PR #107 (déjà mergée).

`testthat::with_mocked_bindings(.get_notes(path = \".\"), ..., .package = \"checkhelper\")`
fonctionnait sous `devtools::test()` parce que `load_all()` expose tout
le namespace, mais cassait sous `R CMD check` où le test tourne contre
le paquet **installé** et où seuls les symboles exportés sont visibles
depuis le frame appelant.

`.get_notes()` est interne (`@noRd`, pas de `@export`). Sans préfixe
explicite `checkhelper:::`, l'expression capturée par
`with_mocked_bindings` ne pouvait pas résoudre le symbole à
l'évaluation. Le test passait par hasard via le chemin load_all.

## Fix

Qualifier les deux sites d'appel avec `checkhelper:::.get_notes(...)`.
La sémantique du mock (rebinding de `rcmdcheck` dans le namespace
checkhelper) est identique.

## Test plan

- [x] `devtools::test(filter = \"fix-globals-light-check\")` → 6/6