### PR TITLE
feat(fix_globals): route operators / pronouns (`:=`, .data, .SD, …) to @importFrom

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,42 @@
 # checkhelper (development version)
 
+## `audit_userspace()` / `check_clean_userspace()` robustness
+
+- The `Run examples` step is now wrapped in a `tryCatch()`. When
+  `devtools::run_examples()` fails deep inside `pkgload` (e.g. the
+  `srcrefs[[1L]]: subscript out of bounds` crash on `@examplesIf`
+  examples whose body is fully under `\donttest{}`, on older R +
+  pkgload combos), the audit no longer aborts: it warns, skips the
+  examples slice, and still runs the unit tests / full check /
+  vignettes steps (#93).
+- On a partial run, the snapshot diff is still computed (rows tagged
+  `source = "Run examples (partial)"`) so files created before the
+  crash do not slip into the next baseline and disappear from the
+  report.
+- The follow-up warning that surfaces files added during examples
+  now lists the files instead of telling the user to "not bother
+  about it" — a real leak written from inside an example would
+  previously have been silently dismissed.
+- `tests/testthat/test-check_clean_userspace.R` no longer hardcodes a
+  `nrow == 5/6/11` cascade. It asserts the invariants the function
+  promises (the seeded leaks are caught, every row has the right
+  shape) instead of an exact OS-dependent row count, so the test now
+  runs on every OS (#54).
+
+## `audit_globals()` / `fix_globals()` skip vignettes / tests / examples
+
+- The internal `R CMD check` triggered by `audit_globals()` and
+  `fix_globals()` now passes
+  `build_args = "--no-build-vignettes"` and
+  `args = c("--no-manual", "--no-tests", "--no-examples", "--no-vignettes")`.
+  The "no visible binding for global variable" /
+  "no visible global function definition" notes come from R CMD
+  check's static `* checking R code for possible problems` step
+  and never depended on those phases. On a vignette-heavy package
+  this turns a multi-minute wait into a few seconds. The defaults
+  are exposed as `build_args` / `args` arguments to `.get_notes()`
+  so a caller can still opt back in if needed.
+
 ## `fix_globals()` separates operators / pronouns from real globals
 
 - `:=`, `.SD`, `.N`, `.I`, `.GRP`, `.BY`, `.EACHI` (data.table),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,42 +1,5 @@
 # checkhelper (development version)
 
-## `audit_userspace()` / `check_clean_userspace()` robustness
-
-- The `Run examples` step is now wrapped in a `tryCatch()`. When
-  `devtools::run_examples()` fails deep inside `pkgload` (e.g. the
-  `srcrefs[[1L]]: subscript out of bounds` crash on `@examplesIf`
-  examples whose body is fully under `\donttest{}`, on older R +
-  pkgload combos), the audit no longer aborts: it warns, skips the
-  examples slice, and still runs the unit tests / full check /
-  vignettes steps (#93).
-- On a partial run, the snapshot diff is still computed (rows tagged
-  `source = "Run examples (partial)"`) so files created before the
-  crash do not slip into the next baseline and disappear from the
-  report.
-- The follow-up warning that surfaces files added during examples
-  now lists the files instead of telling the user to "not bother
-  about it" — a real leak written from inside an example would
-  previously have been silently dismissed.
-- `tests/testthat/test-check_clean_userspace.R` no longer hardcodes a
-  `nrow == 5/6/11` cascade. It asserts the invariants the function
-  promises (the seeded leaks are caught, every row has the right
-  shape) instead of an exact OS-dependent row count, so the test now
-  runs on every OS (#54).
-
-## `audit_globals()` / `fix_globals()` skip vignettes / tests / examples
-
-- The internal `R CMD check` triggered by `audit_globals()` and
-  `fix_globals()` now passes
-  `build_args = "--no-build-vignettes"` and
-  `args = c("--no-manual", "--no-tests", "--no-examples", "--no-vignettes")`.
-  The "no visible binding for global variable" /
-  "no visible global function definition" notes come from R CMD
-  check's static `* checking R code for possible problems` step
-  and never depended on those phases. On a vignette-heavy package
-  this turns a multi-minute wait into a few seconds. The defaults
-  are exposed as `build_args` / `args` arguments to `.get_notes()`
-  so a caller can still opt back in if needed.
-
 ## `fix_globals()` separates operators / pronouns from real globals
 
 - `:=`, `.SD`, `.N`, `.I`, `.GRP`, `.BY`, `.EACHI` (data.table),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,28 @@
 # checkhelper (development version)
 
+## `fix_globals()` separates operators / pronouns from real globals
+
+- `:=`, `.SD`, `.N`, `.I`, `.GRP`, `.BY`, `.EACHI` (data.table),
+  `.data`, `.env`, `!!`, `!!!` (rlang) are no longer routed into the
+  `utils::globalVariables(c(...))` block. They are exports from
+  another package - not undeclared variables - and the right fix is
+  an `@importFrom` line, not a `globalVariables()` entry.
+- `audit_globals()` / `.get_no_visible()` now return a third tibble
+  `operators` next to `globalVariables` and `functions`. The token
+  is paired with its candidate source package(s).
+- `fix_globals()` prints a third section
+  *"Operators / pronouns to import via NAMESPACE"* with ready-to-paste
+  `#' @importFrom <pkg> <token>` lines. When the source is ambiguous
+  (`:=` is exported by both data.table and rlang) every candidate is
+  listed and the user picks one consciously - no silent guessing.
+- `fix_globals(write = TRUE)` only writes real globals to
+  `R/globals.R`. The operators section is printed on stdout so the
+  user wires the `@importFrom` lines into NAMESPACE manually.
+- The internal regex that extracts the function name from a check
+  note (`fun = str_extract(fun, ".+(?=:)")`) was greedy and ate the
+  whole prose of `:=` notes. Anchored to the first `:` so it now
+  reports the actual caller.
+
 ## `fix_globals(write = TRUE)` now merges with the existing `R/globals.R`
 
 - Previously, `fix_globals(write = TRUE)` overwrote `R/globals.R`

--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -11,8 +11,14 @@
 #'   reuses it instead of re-running `R CMD check` on `pkg`. Useful to share
 #'   a single check between [audit_globals()] and [fix_globals()].
 #'
-#' @return A list with two tibbles, `globalVariables` and `functions`,
-#'   or `NULL` if the package has no global notes.
+#' @return A list with three tibbles, `globalVariables`, `functions`
+#'   and `operators`, or `NULL` if the package has no global notes.
+#'   `globalVariables` collects names that need a
+#'   `utils::globalVariables()` declaration; `functions` collects
+#'   external functions to import via `@importFrom`; `operators`
+#'   collects NSE tokens / data.table / rlang pronouns (`:=`,
+#'   `.SD`, `.data`, `!!`, …) that also need `@importFrom` rather
+#'   than a `globalVariables()` entry.
 #' @export
 #' @seealso [fix_globals()], [get_no_visible()].
 #' @examples
@@ -102,9 +108,20 @@ fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
     if (has_operators) {
       message(printed[["liste_operators"]])
     }
+    # Two destinations: the globalVariables block goes to
+    # R/globals.R; the operators / pronouns block goes to a roxygen
+    # `@importFrom` somewhere in the package (any R file). Don't
+    # collapse them into a single "paste above into R/globals.R"
+    # message (Copilot review of #110: that wording would have the
+    # user paste NAMESPACE concerns into globals.R).
     cli::cli_inform(c(
-      "i" = "fix_globals(): paste the block above into R/globals.R, or call fix_globals(write = TRUE)."
+      "i" = "fix_globals(): paste the `utils::globalVariables(...)` block above into R/globals.R, or call fix_globals(write = TRUE)."
     ))
+    if (has_operators) {
+      cli::cli_inform(c(
+        "i" = "fix_globals(): paste the operators / pronouns `@importFrom` lines into a roxygen block in any R file (e.g. R/utils-imports.R), NOT into R/globals.R."
+      ))
+    }
     return(invisible(NULL))
   }
 
@@ -532,25 +549,32 @@ format_operators_section <- function(operators) {
     for (i in seq_len(nrow(amb))) {
       sym <- amb$variable[i]
       candidates <- strsplit(amb$source_pkg[i], ";", fixed = TRUE)[[1]]
+      # `# #'` would be invisible to roxygen2 — pasting verbatim
+       # gives the user zero @importFrom declared (Copilot review of
+       # #110). Emit the lines as real `#'` and add a `# KEEP ONE:`
+       # banner so the user knows to delete every other line.
       ambiguous_lines <- c(
         ambiguous_lines,
         sprintf(
-          "# `%s` is exported by %s -- pick the one your package uses:",
+          "# `%s` is exported by %s - KEEP ONE of the lines below, delete the other:",
           sym,
           paste0("'", candidates, "'", collapse = " or ")
         ),
         vapply(
           candidates,
-          function(pkg) paste0("# #' @importFrom ", pkg, " ", sym),
+          function(pkg) paste0("#' @importFrom ", pkg, " ", sym),
           character(1)
         )
       )
     }
   }
 
+  # Banners are `#`-prefixed so the whole block survives a verbatim
+  # paste into an R file (Copilot review of #110: the previous bare
+  # `--- ... ---` lines parse-errored when pasted as-is).
   paste(c(
-    "--- Operators / pronouns to import via NAMESPACE ---",
-    "-- add to an R file (e.g. R/utils-imports.R) --",
+    "# --- Operators / pronouns to import via NAMESPACE ---",
+    "# --- add to an R file (e.g. R/utils-imports.R) ---",
     "",
     unambiguous_lines,
     ambiguous_lines,

--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -110,10 +110,9 @@ fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
     }
     # Two destinations: the globalVariables block goes to
     # R/globals.R; the operators / pronouns block goes to a roxygen
-    # `@importFrom` somewhere in the package (any R file). Don't
-    # collapse them into a single "paste above into R/globals.R"
-    # message (Copilot review of #110: that wording would have the
-    # user paste NAMESPACE concerns into globals.R).
+    # `@importFrom` somewhere in the package (any R file). Keep the
+    # two cli messages separate so the user does not paste NAMESPACE
+    # concerns into globals.R.
     cli::cli_inform(c(
       "i" = "fix_globals(): paste the `utils::globalVariables(...)` block above into R/globals.R, or call fix_globals(write = TRUE)."
     ))
@@ -550,9 +549,9 @@ format_operators_section <- function(operators) {
       sym <- amb$variable[i]
       candidates <- strsplit(amb$source_pkg[i], ";", fixed = TRUE)[[1]]
       # `# #'` would be invisible to roxygen2 — pasting verbatim
-       # gives the user zero @importFrom declared (Copilot review of
-       # #110). Emit the lines as real `#'` and add a `# KEEP ONE:`
-       # banner so the user knows to delete every other line.
+       # gives the user zero @importFrom declared. Emit the lines as
+       # real `#'` and add a `# KEEP ONE:` banner so the user knows
+       # to delete every other line.
       ambiguous_lines <- c(
         ambiguous_lines,
         sprintf(
@@ -570,8 +569,7 @@ format_operators_section <- function(operators) {
   }
 
   # Banners are `#`-prefixed so the whole block survives a verbatim
-  # paste into an R file (Copilot review of #110: the previous bare
-  # `--- ... ---` lines parse-errored when pasted as-is).
+  # paste into an R file. Bare `--- ... ---` would parse-error.
   paste(c(
     "# --- Operators / pronouns to import via NAMESPACE ---",
     "# --- add to an R file (e.g. R/utils-imports.R) ---",

--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -94,9 +94,14 @@ fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
 
   printed <- .print_globals(globals = globals, message = FALSE)
 
+  has_operators <- nzchar(printed[["liste_operators"]])
+
   if (!isTRUE(write)) {
     message(printed[["liste_funs"]])
     message(printed[["liste_globals"]])
+    if (has_operators) {
+      message(printed[["liste_operators"]])
+    }
     cli::cli_inform(c(
       "i" = "fix_globals(): paste the block above into R/globals.R, or call fix_globals(write = TRUE)."
     ))
@@ -121,12 +126,44 @@ fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
   cli::cli_inform(c(
     "v" = "fix_globals(): wrote globalVariables block to {.file {globals_path}} (merged with {length(preserved)} previously declared name{?s})."
   ))
+  # Operators / pronouns must NOT go into R/globals.R because they are
+  # exports from another package, not undeclared variables. Surface the
+  # @importFrom suggestions on stdout so the user can wire them into
+  # NAMESPACE explicitly.
+  if (has_operators) {
+    message(printed[["liste_operators"]])
+    cli::cli_inform(c(
+      "i" = "fix_globals(): operators / pronouns above need an `@importFrom` line, NOT a globalVariables() entry — see operators section."
+    ))
+  }
 
   invisible(globals_path)
 }
 
 
 # Internal implementations ---------------------------------------------------
+
+#' Tokens that R CMD check flags as "no visible global ..." but that are
+#' actually exports from another package - the right fix is `@importFrom`,
+#' not a `globalVariables()` entry. Each token maps to the candidate
+#' source package(s); when more than one applies (`:=` is exported by
+#' both data.table and rlang), `.print_globals()` lists every candidate
+#' so the user picks one consciously.
+#'
+#' @noRd
+.known_operators <- list(
+  ":="     = c("data.table", "rlang"),
+  ".SD"    = "data.table",
+  ".N"     = "data.table",
+  ".I"     = "data.table",
+  ".GRP"   = "data.table",
+  ".BY"    = "data.table",
+  ".EACHI" = "data.table",
+  ".data"  = "rlang",
+  ".env"   = "rlang",
+  "!!"     = "rlang",
+  "!!!"    = "rlang"
+)
 
 #' Extract the names already declared by `globalVariables()` calls in
 #' an existing `R/globals.R`. Returns `character(0)` when the file
@@ -302,7 +339,12 @@ merge_globals_block <- function(fresh_block, preserved) {
       filepath = str_extract(notes, "(\\s*\\(.*\\)\\s*){0,1}"),
       filepath = ifelse(filepath == "", "-", filepath),
       fun = purrr::map2_chr(notes, filepath, ~ gsub(.y, "", .x, fixed = TRUE)),
-      fun = str_extract(fun, ".+(?=:)"),
+      # Anchored, non-colon match: capture only up to the *first*
+      # colon. The historical greedy `.+(?=:)` would happily eat past
+      # the colon for e.g. ":=" notes (`fn: no visible global function
+      # definition for ':='`), capturing the entire prose of the note
+      # as the function name and breaking the operators-import path.
+      fun = str_extract(fun, "^[^:]+(?=:)"),
       is_function = grepl("no visible global function definition", notes),
       is_global_variable = grepl("no visible binding for global variable", notes),
       variable = str_extract(notes, "(?<=\\u2018).+(?=\\u2019)|(?<=\\u0027).+(?=\\u0027)"),
@@ -342,13 +384,31 @@ merge_globals_block <- function(fresh_block, preserved) {
   fun_names <- notes %>%
     filter(is_global_variable | is_function) %>%
     select(-importfrom_function, -is_importfrom) %>%
-    left_join(proposed, by = c("variable" = "importfrom_function"))
+    left_join(proposed, by = c("variable" = "importfrom_function")) %>%
+    mutate(is_operator = variable %in% names(.known_operators))
+
+  # Operators / pronouns (`:=`, `.data`, `.SD`, `!!`, ...) get their own
+  # bucket. They will be rendered as `@importFrom <pkg> <token>`
+  # suggestions, never as `globalVariables()` entries (which would be
+  # semantically wrong: they are not undeclared variables, they are
+  # exports from another package).
+  ops_tbl <- fun_names %>%
+    filter(is_operator) %>%
+    select(fun, variable) %>%
+    mutate(source_pkg = vapply(
+      variable,
+      function(v) paste(.known_operators[[v]], collapse = ";"),
+      character(1)
+    ))
 
   list(
     globalVariables = fun_names %>%
-      filter(is_global_variable),
+      filter(is_global_variable & !is_operator) %>%
+      select(-is_operator),
     functions = fun_names %>%
-      filter(is_function)
+      filter(is_function & !is_operator) %>%
+      select(-is_operator),
+    operators = ops_tbl
   )
 }
 
@@ -370,7 +430,8 @@ merge_globals_block <- function(fresh_block, preserved) {
     }
   }
 
-  if (!isTRUE(is.list(globals) & length(globals) == 2)) {
+  required_keys <- c("globalVariables", "functions")
+  if (!is.list(globals) || !all(required_keys %in% names(globals))) {
     stop("globals should be a list as issued from 'get_no_visible()' or empty")
   }
 
@@ -422,13 +483,77 @@ merge_globals_block <- function(fresh_block, preserved) {
     liste_globals_code
   )
 
+  liste_operators <- format_operators_section(globals[["operators"]])
+
   if (isTRUE(message)) {
-    message(glue(liste_funs, "\n", liste_globals))
+    message(glue(liste_funs, "\n", liste_globals, "\n", liste_operators))
   } else {
     list(
       liste_funs = liste_funs,
       liste_globals = liste_globals,
-      liste_globals_code = liste_globals_code
+      liste_globals_code = liste_globals_code,
+      liste_operators = liste_operators
     )
   }
+}
+
+#' Format the third section of `.print_globals()` output: a set of
+#' `@importFrom` lines for the operators / pronouns surfaced by
+#' `.get_no_visible()`. When a token is exported by more than one
+#' candidate package (currently only `:=` from data.table OR rlang),
+#' every candidate is listed and the user picks one consciously — no
+#' silent guessing.
+#' @noRd
+format_operators_section <- function(operators) {
+  if (is.null(operators) || nrow(operators) == 0L) {
+    return("")
+  }
+
+  uniq <- operators[!duplicated(operators$variable), c("variable", "source_pkg")]
+  is_ambiguous <- grepl(";", uniq$source_pkg, fixed = TRUE)
+
+  unambiguous_lines <- character(0)
+  if (any(!is_ambiguous)) {
+    unamb <- uniq[!is_ambiguous, , drop = FALSE]
+    by_pkg <- split(unamb$variable, unamb$source_pkg)
+    unambiguous_lines <- vapply(
+      names(by_pkg),
+      function(pkg) {
+        toks <- sort(unique(by_pkg[[pkg]]))
+        paste0("#' @importFrom ", pkg, " ", paste(toks, collapse = " "))
+      },
+      character(1)
+    )
+  }
+
+  ambiguous_lines <- character(0)
+  if (any(is_ambiguous)) {
+    amb <- uniq[is_ambiguous, , drop = FALSE]
+    for (i in seq_len(nrow(amb))) {
+      sym <- amb$variable[i]
+      candidates <- strsplit(amb$source_pkg[i], ";", fixed = TRUE)[[1]]
+      ambiguous_lines <- c(
+        ambiguous_lines,
+        sprintf(
+          "# `%s` is exported by %s -- pick the one your package uses:",
+          sym,
+          paste0("'", candidates, "'", collapse = " or ")
+        ),
+        vapply(
+          candidates,
+          function(pkg) paste0("# #' @importFrom ", pkg, " ", sym),
+          character(1)
+        )
+      )
+    }
+  }
+
+  paste(c(
+    "--- Operators / pronouns to import via NAMESPACE ---",
+    "-- add to an R file (e.g. R/utils-imports.R) --",
+    "",
+    unambiguous_lines,
+    ambiguous_lines,
+    "NULL"
+  ), collapse = "\n")
 }

--- a/man/audit_globals.Rd
+++ b/man/audit_globals.Rd
@@ -15,8 +15,14 @@ reuses it instead of re-running \verb{R CMD check} on \code{pkg}. Useful to shar
 a single check between \code{\link[=audit_globals]{audit_globals()}} and \code{\link[=fix_globals]{fix_globals()}}.}
 }
 \value{
-A list with two tibbles, \code{globalVariables} and \code{functions},
-or \code{NULL} if the package has no global notes.
+A list with three tibbles, \code{globalVariables}, \code{functions}
+and \code{operators}, or \code{NULL} if the package has no global notes.
+\code{globalVariables} collects names that need a
+\code{utils::globalVariables()} declaration; \code{functions} collects
+external functions to import via \verb{@importFrom}; \code{operators}
+collects NSE tokens / data.table / rlang pronouns (\verb{:=},
+\code{.SD}, \code{.data}, \verb{!!}, …) that also need \verb{@importFrom} rather
+than a \code{globalVariables()} entry.
 }
 \description{
 Runs \verb{R CMD check} on the package and extracts every

--- a/tests/testthat/test-audit-globals.R
+++ b/tests/testthat/test-audit-globals.R
@@ -4,7 +4,7 @@ test_that("audit_globals() exists with the expected signature", {
   expect_null(eval(formals(audit_globals)$checks))
 })
 
-test_that("audit_globals() returns either NULL or a 2-element list (globalVariables, functions)", {
+test_that("audit_globals() returns either NULL or a list with globalVariables / functions / operators", {
   skip_on_cran()
   local_tempdir_clean()
   path <- suppressWarnings(create_example_pkg())
@@ -12,7 +12,7 @@ test_that("audit_globals() returns either NULL or a 2-element list (globalVariab
   out <- suppressMessages(suppressWarnings(audit_globals(path)))
   if (!is.null(out)) {
     expect_type(out, "list")
-    expect_named(out, c("globalVariables", "functions"))
+    expect_named(out, c("globalVariables", "functions", "operators"))
   } else {
     succeed("audit_globals returned NULL — package had no notes")
   }
@@ -54,7 +54,7 @@ test_that("audit_globals(checks = ...) reuses a precomputed rcmdcheck and does n
   )
 
   expect_type(out, "list")
-  expect_named(out, c("globalVariables", "functions"))
+  expect_named(out, c("globalVariables", "functions", "operators"))
   expect_true("foo" %in% out$globalVariables$variable)
   expect_true("bar" %in% out$functions$variable)
 })

--- a/tests/testthat/test-fix-globals-operators.R
+++ b/tests/testthat/test-fix-globals-operators.R
@@ -32,7 +32,7 @@ test_that(":= is routed to operators, not to globalVariables", {
     note_var("indicator_fn", "real_global")
   ))
 
-  res <- .get_no_visible(checks = chk)
+  res <- checkhelper:::.get_no_visible(checks = chk)
 
   expect_true("operators" %in% names(res),
     info = "the no-visible struct must surface a third bucket for operators"
@@ -42,7 +42,7 @@ test_that(":= is routed to operators, not to globalVariables", {
   expect_false(":=" %in% res$functions$variable)
   expect_true("real_global" %in% res$globalVariables$variable)
 
-  printed <- .print_globals(res, message = FALSE)
+  printed <- checkhelper:::.print_globals(res, message = FALSE)
 
   # The Rd payload (what gets written to R/globals.R) must keep the
   # real global and drop the operator.
@@ -62,8 +62,8 @@ test_that(".data and .env are routed to operators (rlang pronouns)", {
     note_var("my_fn", "real_col")
   ))
 
-  res <- .get_no_visible(checks = chk)
-  printed <- .print_globals(res, message = FALSE)
+  res <- checkhelper:::.get_no_visible(checks = chk)
+  printed <- checkhelper:::.print_globals(res, message = FALSE)
 
   expect_setequal(res$operators$variable, c(".data", ".env"))
   expect_setequal(res$globalVariables$variable, "real_col")
@@ -79,8 +79,8 @@ test_that("data.table pronouns (.SD, .N, .I, .GRP, .BY, .EACHI) are routed to op
   notes <- vapply(toks, function(t) note_var("dt_fn", t), character(1))
   chk <- fake_check_with_notes(notes)
 
-  res <- .get_no_visible(checks = chk)
-  printed <- .print_globals(res, message = FALSE)
+  res <- checkhelper:::.get_no_visible(checks = chk)
+  printed <- checkhelper:::.print_globals(res, message = FALSE)
 
   expect_setequal(res$operators$variable, toks)
   expect_equal(nrow(res$globalVariables), 0L)
@@ -93,7 +93,10 @@ test_that("data.table pronouns (.SD, .N, .I, .GRP, .BY, .EACHI) are routed to op
 
 test_that("ambiguous source (`:=` from data.table OR rlang) lists both candidates", {
   chk <- fake_check_with_notes(note_fun("my_fn", ":="))
-  printed <- .print_globals(.get_no_visible(checks = chk), message = FALSE)
+  printed <- checkhelper:::.print_globals(
+    checkhelper:::.get_no_visible(checks = chk),
+    message = FALSE
+  )
 
   # Both candidate packages must be visible — never silently pick one.
   expect_match(printed$liste_operators, "data.table", fixed = TRUE)
@@ -106,8 +109,8 @@ test_that("plain global variables still go to utils::globalVariables() (no regre
     note_var("fn", "var2")
   ))
 
-  res <- .get_no_visible(checks = chk)
-  printed <- .print_globals(res, message = FALSE)
+  res <- checkhelper:::.get_no_visible(checks = chk)
+  printed <- checkhelper:::.print_globals(res, message = FALSE)
 
   expect_equal(nrow(res$operators), 0L)
   expect_setequal(res$globalVariables$variable, c("var1", "var2"))

--- a/tests/testthat/test-fix-globals-operators.R
+++ b/tests/testthat/test-fix-globals-operators.R
@@ -1,0 +1,116 @@
+# Regression test: fix_globals() must not glue NSE operators / data.table
+# pronouns / rlang quasiquotation tokens into the
+# `utils::globalVariables(c(...))` block. Those are not undeclared
+# variables — they are exports from another package and the right fix
+# is `@importFrom`. See user request: `:=`, `.SD`, `.N`, `.I`, `.GRP`,
+# `.BY`, `.EACHI` (data.table) and `.data`, `.env`, `!!`, `!!!`
+# (rlang).
+
+fake_check_with_notes <- function(...) {
+  # R CMD check emits one big note block with many lines, not many
+  # notes with one line each. Mirror that structure so .get_notes()
+  # downstream parses every line we feed it.
+  lines <- c(...)
+  list(notes = paste0(
+    "checking R code for possible problems ... NOTE\n",
+    paste(lines, collapse = "\n"),
+    "\n"
+  ))
+}
+
+# A single check note LINE (no NOTE header, no trailing newline).
+note_var <- function(fun, var) {
+  paste0(fun, ": no visible binding for global variable ‘", var, "’")
+}
+note_fun <- function(fun, var) {
+  paste0(fun, ": no visible global function definition for ‘", var, "’")
+}
+
+test_that(":= is routed to operators, not to globalVariables", {
+  chk <- fake_check_with_notes(c(
+    note_fun("indicator_fn", ":="),
+    note_var("indicator_fn", "real_global")
+  ))
+
+  res <- .get_no_visible(checks = chk)
+
+  expect_true("operators" %in% names(res),
+    info = "the no-visible struct must surface a third bucket for operators"
+  )
+  expect_true(":=" %in% res$operators$variable)
+  expect_false(":=" %in% res$globalVariables$variable)
+  expect_false(":=" %in% res$functions$variable)
+  expect_true("real_global" %in% res$globalVariables$variable)
+
+  printed <- .print_globals(res, message = FALSE)
+
+  # The Rd payload (what gets written to R/globals.R) must keep the
+  # real global and drop the operator.
+  expect_match(printed$liste_globals_code, "real_global", fixed = TRUE)
+  expect_no_match(printed$liste_globals_code, ":=", fixed = TRUE)
+
+  # An operators section must exist with an @importFrom suggestion.
+  expect_true("liste_operators" %in% names(printed))
+  expect_match(printed$liste_operators, "@importFrom", fixed = TRUE)
+  expect_match(printed$liste_operators, ":=", fixed = TRUE)
+})
+
+test_that(".data and .env are routed to operators (rlang pronouns)", {
+  chk <- fake_check_with_notes(c(
+    note_var("my_fn", ".data"),
+    note_var("my_fn", ".env"),
+    note_var("my_fn", "real_col")
+  ))
+
+  res <- .get_no_visible(checks = chk)
+  printed <- .print_globals(res, message = FALSE)
+
+  expect_setequal(res$operators$variable, c(".data", ".env"))
+  expect_setequal(res$globalVariables$variable, "real_col")
+
+  expect_match(printed$liste_globals_code, "real_col", fixed = TRUE)
+  expect_no_match(printed$liste_globals_code, ".data", fixed = TRUE)
+  expect_no_match(printed$liste_globals_code, ".env", fixed = TRUE)
+  expect_match(printed$liste_operators, "@importFrom rlang", fixed = TRUE)
+})
+
+test_that("data.table pronouns (.SD, .N, .I, .GRP, .BY, .EACHI) are routed to operators", {
+  toks <- c(".SD", ".N", ".I", ".GRP", ".BY", ".EACHI")
+  notes <- vapply(toks, function(t) note_var("dt_fn", t), character(1))
+  chk <- fake_check_with_notes(notes)
+
+  res <- .get_no_visible(checks = chk)
+  printed <- .print_globals(res, message = FALSE)
+
+  expect_setequal(res$operators$variable, toks)
+  expect_equal(nrow(res$globalVariables), 0L)
+
+  for (t in toks) {
+    expect_no_match(printed$liste_globals_code, t, fixed = TRUE)
+  }
+  expect_match(printed$liste_operators, "@importFrom data.table", fixed = TRUE)
+})
+
+test_that("ambiguous source (`:=` from data.table OR rlang) lists both candidates", {
+  chk <- fake_check_with_notes(note_fun("my_fn", ":="))
+  printed <- .print_globals(.get_no_visible(checks = chk), message = FALSE)
+
+  # Both candidate packages must be visible — never silently pick one.
+  expect_match(printed$liste_operators, "data.table", fixed = TRUE)
+  expect_match(printed$liste_operators, "rlang", fixed = TRUE)
+})
+
+test_that("plain global variables still go to utils::globalVariables() (no regression)", {
+  chk <- fake_check_with_notes(c(
+    note_var("fn", "var1"),
+    note_var("fn", "var2")
+  ))
+
+  res <- .get_no_visible(checks = chk)
+  printed <- .print_globals(res, message = FALSE)
+
+  expect_equal(nrow(res$operators), 0L)
+  expect_setequal(res$globalVariables$variable, c("var1", "var2"))
+  expect_match(printed$liste_globals_code, "var1", fixed = TRUE)
+  expect_match(printed$liste_globals_code, "var2", fixed = TRUE)
+})


### PR DESCRIPTION
## Pourquoi

`R CMD check` signale `:=`, `.SD`, `.N`, `.I`, `.GRP`, `.BY`, `.EACHI`,
`.data`, `.env`, `!!`, `!!!` comme "no visible global …" quand le
paquet les utilise sans `@importFrom`. `fix_globals()` les collait
dans `utils::globalVariables(c(...))` — techniquement valide mais
**sémantiquement faux** : ce sont des exports d'un autre paquet, pas
des variables non déclarées. Le bon fix est `@importFrom <pkg> <op>`
dans NAMESPACE.

Exemple problématique avant la PR (paquet utilisant data.table) :

```
utils::globalVariables(unique(c(
  # IndColza_simple:
  ":=",
  # get_STPoisP:
  "CODE_DEPT", "ZONE", "ZONE_PoisP"
)))
```

Après la PR, on a deux sections distinctes : `:=` part dans la
section operators, les vraies variables restent dans
`utils::globalVariables()`.

## Implémentation

- Constante interne `.known_operators` qui map chaque token à son
  ou ses paquets sources candidats. data.table pour les pronouns
  dt, rlang pour `.data` / `.env` / quasiquotation. `:=` est ambigu
  (les deux paquets l'exportent).
- `.get_no_visible()` retourne maintenant une liste à 3 clés :
  `globalVariables`, `functions`, `operators`. Les tokens operator
  sont filtrés des deux premiers buckets.
- `.print_globals()` gagne un payload `liste_operators` qui rend
  des lignes `#' @importFrom <pkg> <tok>` prêtes à coller, groupées
  par paquet. Pour les tokens ambigus, **chaque candidat est listé**
  et l'utilisateur choisit (pas de devinette silencieuse).
- `fix_globals(write = TRUE)` n'écrit que les vraies globales dans
  `R/globals.R`. La section operators est affichée sur stdout.

### Bonus

Le regex `fun = str_extract(fun, ".+(?=:)")` était greedy et
capturait toute la prose des notes pour `:=` (`fn: no visible … for ':='`)
comme nom de fonction, cassant complètement le routage. Ancré sur le
premier `:` (`^[^:]+(?=:)`), ça donne enfin le vrai caller.

## TDD

Test rouge d'abord (`tests/testthat/test-fix-globals-operators.R`),
5 cas :

1. `:=` routé vers `operators`, **pas** dans `liste_globals_code`.
2. `.data` / `.env` (rlang) routés vers `operators`.
3. Pronouns data.table (`.SD`, `.N`, `.I`, `.GRP`, `.BY`, `.EACHI`)
   routés.
4. Ambigu (`:=`) → les deux paquets listés.
5. Vraies globales inchangées.

Avant : 10 FAIL (la clé `operators` n'existait pas). Après : 31
expectations vertes.

## Test plan

- [x] `devtools::test(filter = "fix-globals-operators")` → 31/31
- [x] `devtools::test(filter = "globals")` → pas de régression
- [x] `devtools::test()` complet → 0 fail