### PR TITLE
fix(pkgdown): register audit_citation in reference index

### DIFF
--- a/R/audit_globals.R
+++ b/R/audit_globals.R
@@ -17,7 +17,7 @@
 #'   `utils::globalVariables()` declaration; `functions` collects
 #'   external functions to import via `@importFrom`; `operators`
 #'   collects NSE tokens / data.table / rlang pronouns (`:=`,
-#'   `.SD`, `.data`, `!!`, …) that also need `@importFrom` rather
+#'   `.SD`, `.data`, `!!`, ...) that also need `@importFrom` rather
 #'   than a `globalVariables()` entry.
 #' @export
 #' @seealso [fix_globals()], [get_no_visible()].
@@ -133,7 +133,7 @@ fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
   # out names already covered by an existing globalVariables() call,
   # so by the time fix_globals() runs the second time, the new notes
   # only list *uncovered* names. Overwriting would erase the curated
-  # set and re-flag those names on the very next check — a circular
+  # set and re-flag those names on the very next check - a circular
   # game the user can never win.
   preserved <- extract_existing_globals(globals_path)
   merged_block <- merge_globals_block(printed[["liste_globals_code"]], preserved)
@@ -149,7 +149,7 @@ fix_globals <- function(pkg = ".", write = FALSE, checks = NULL) {
   if (has_operators) {
     message(printed[["liste_operators"]])
     cli::cli_inform(c(
-      "i" = "fix_globals(): operators / pronouns above need an `@importFrom` line, NOT a globalVariables() entry — see operators section."
+      "i" = "fix_globals(): operators / pronouns above need an `@importFrom` line, NOT a globalVariables() entry - see operators section."
     ))
   }
 
@@ -216,9 +216,9 @@ extract_existing_globals <- function(globals_path) {
 #' Recursively collect every character-literal leaf of an unevaluated R
 #' expression. Used by `extract_existing_globals()` to read the names
 #' from an existing `R/globals.R` without ever calling `eval()` on the
-#' file's contents — the historic `eval(arg, envir = safe_env)` ran
+#' file's contents - the historic `eval(arg, envir = safe_env)` ran
 #' under `baseenv()` (which exposes `system()`, `library()`, `file()`,
-#' …), so a crafted `globals.R` could execute arbitrary code at
+#' ...), so a crafted `globals.R` could execute arbitrary code at
 #' `fix_globals(write = TRUE)` time.
 #'
 #' Symbols, numerics, logicals, `NULL`, and arbitrary calls
@@ -517,7 +517,7 @@ merge_globals_block <- function(fresh_block, preserved) {
 #' `@importFrom` lines for the operators / pronouns surfaced by
 #' `.get_no_visible()`. When a token is exported by more than one
 #' candidate package (currently only `:=` from data.table OR rlang),
-#' every candidate is listed and the user picks one consciously — no
+#' every candidate is listed and the user picks one consciously - no
 #' silent guessing.
 #' @noRd
 format_operators_section <- function(operators) {
@@ -548,7 +548,7 @@ format_operators_section <- function(operators) {
     for (i in seq_len(nrow(amb))) {
       sym <- amb$variable[i]
       candidates <- strsplit(amb$source_pkg[i], ";", fixed = TRUE)[[1]]
-      # `# #'` would be invisible to roxygen2 — pasting verbatim
+      # `# #'` would be invisible to roxygen2 - pasting verbatim
        # gives the user zero @importFrom declared. Emit the lines as
        # real `#'` and add a `# KEEP ONE:` banner so the user knows
        # to delete every other line.

--- a/R/globals.R
+++ b/R/globals.R
@@ -2,7 +2,7 @@ globalVariables(
   unique(
     c(
       "is_importfrom", "importfrom_function", "is_global_variable",
-      "is_function", "notes", "variable", ".",
+      "is_function", "is_operator", "notes", "variable", ".",
       # print_globals:
       "fun", "text",
       # find_missing_tags

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -25,6 +25,7 @@ reference:
   - audit_userspace
   - audit_check
   - audit_dataset_doc
+  - audit_citation
 
 - title: Fix
   desc: >


### PR DESCRIPTION
## Summary

This PR fixes pkgdown CI on `main`, plus two latent issues that #110 introduced into the same audit subsystem and that surface on the same CI run.

1. pkgdown was failing on `main` since #111 was merged: `audit_citation()` is exported and has an Rd page, but it was never added to `_pkgdown.yml`. pkgdown's strict missing-topic check aborts the build (`In _pkgdown.yml, 1 topic missing from index: 'audit_citation'`).
   - Fix: add `audit_citation` to the `Audit` section of the reference index, alongside the other `audit_*` facades (`_pkgdown.yml`).
2. `R CMD check` WARNING for non-ASCII characters in an R source file: `R/audit_globals.R` contained U+2014 / U+2026 from #110.
   - Fix: replace with ASCII equivalents (`-`, `...`).
3. `R CMD check` NOTE for undefined global `is_operator` introduced by the new audit code in #110.
   - Fix: declare it in `R/globals.R` `globalVariables()`.

## Test plan

- [ ] Confirm the pkgdown CI run on this PR turns green.
- [ ] Confirm `R CMD check` no longer emits the non-ASCII WARNING or the `is_operator` NOTE.
- [ ] After merge, confirm the next CI run on `main` is green end-to-end.