### PR TITLE
docs: sync vignette + README quick start with new audits

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -31,6 +31,7 @@ Each category of CRAN issue gets one read-only `audit_*()` function and, when an
 | `R CMD check` with CRAN settings | `audit_check()` | - |
 | Undocumented datasets | `audit_dataset_doc()` | `fix_dataset_doc()` |
 | Old-style `inst/CITATION` | `audit_citation()` | - |
+| `\dontrun{}` blocks in examples | `audit_dontrun()` | - |
 
 Lower-level helpers (`asciify_file()`, `asciify_r_source()`, `find_nonascii_tokens()`, `create_example_pkg()`) are also exported for fine-grained scripting.
 
@@ -85,6 +86,8 @@ chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
 audit_tags(pkg)
 audit_ascii(pkg)
 audit_dataset_doc(pkg)
+audit_citation(pkg)
+audit_dontrun(pkg)
 
 # Audits that consume the check - reuse `chk` via the `checks =` argument.
 audit_globals(pkg, checks = chk)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
 audit_tags(pkg)
 audit_ascii(pkg)
 audit_dataset_doc(pkg)
+audit_citation(pkg)
+audit_dontrun(pkg)
 
 # Audits that consume the check - reuse `chk` via the `checks =` argument.
 audit_globals(pkg, checks = chk)

--- a/vignettes/auditing-an-r-package.Rmd
+++ b/vignettes/auditing-an-r-package.Rmd
@@ -38,7 +38,7 @@ chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
 
 # 2. Static audits (no extra check needed).
 audit_tags(pkg)            # exported funs without @return / internals without @noRd
-audit_ascii(pkg)           # non-ASCII characters in R/, tests/, vignettes/, man/
+audit_ascii(pkg)           # non-ASCII characters in R/, tests/, vignettes/, man/, DESCRIPTION, NAMESPACE
 audit_dataset_doc(pkg)     # datasets in data/ without a roxygen block
 audit_citation(pkg)        # old-style personList() / citEntry() in inst/CITATION
 audit_dontrun(pkg)         # \dontrun{} blocks in man/*.Rd
@@ -84,7 +84,7 @@ The other audits do not need a check at all:
 | Audit                | Needs `R CMD check`?  | Notes                                  |
 |----------------------|-----------------------|----------------------------------------|
 | `audit_tags()`       | no                    | static via roxygen2                    |
-| `audit_ascii()`      | no                    | AST via `getParseData()`               |
+| `audit_ascii()`      | no                    | line-by-line via `stringi::stri_enc_isascii()` |
 | `audit_dataset_doc()`| no                    | inspects `data/` and `R/`              |
 | `audit_citation()`   | no                    | static parse of `inst/CITATION`        |
 | `audit_dontrun()`    | no                    | line-by-line scan of `man/*.Rd`        |
@@ -137,9 +137,10 @@ audit_tags(pkg)
 
 ### Non-ASCII characters
 
-`audit_ascii()` walks `R/`, `tests/`, `vignettes/`, `man/` and
-DESCRIPTION line-by-line and reports every line containing
-non-ASCII characters (columns: `file`, `line`, `text`, `n_tokens`).
+`audit_ascii()` walks `R/`, `tests/`, `vignettes/`, `man/`,
+`DESCRIPTION` and `NAMESPACE` line-by-line and reports every line
+containing non-ASCII characters (columns: `file`, `line`, `text`,
+`n_tokens`).
 `fix_ascii()` then rewrites them - using the parser AST so each
 token is rewritten per its context: string literals become `\uXXXX`
 escapes, comments and roxygen get `Latin-ASCII` transliteration.

--- a/vignettes/auditing-an-r-package.Rmd
+++ b/vignettes/auditing-an-r-package.Rmd
@@ -40,6 +40,8 @@ chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
 audit_tags(pkg)            # exported funs without @return / internals without @noRd
 audit_ascii(pkg)           # non-ASCII characters in R/, tests/, vignettes/, man/
 audit_dataset_doc(pkg)     # datasets in data/ without a roxygen block
+audit_citation(pkg)        # old-style personList() / citEntry() in inst/CITATION
+audit_dontrun(pkg)         # \dontrun{} blocks in man/*.Rd
 
 # 3. Audits that need the check output - pass `chk` to skip a 2nd run.
 audit_globals(pkg, checks = chk)
@@ -84,6 +86,8 @@ The other audits do not need a check at all:
 | `audit_tags()`       | no                    | static via roxygen2                    |
 | `audit_ascii()`      | no                    | AST via `getParseData()`               |
 | `audit_dataset_doc()`| no                    | inspects `data/` and `R/`              |
+| `audit_citation()`   | no                    | static parse of `inst/CITATION`        |
+| `audit_dontrun()`    | no                    | line-by-line scan of `man/*.Rd`        |
 | `audit_globals()`    | **yes** (reusable)    | accepts `checks =`                     |
 | `audit_userspace()`  | yes (own pipeline)    | takes file-system snapshots, separate  |
 | `audit_check()`      | yes                   | this **is** the check, with CRAN env   |
@@ -92,17 +96,34 @@ The other audits do not need a check at all:
 
 ### Globals (`no visible binding`)
 
-`audit_globals()` returns a 2-element list (`globalVariables`,
-`functions`) of names CRAN flagged. `fix_globals(write = TRUE)`
-materializes them into `R/globals.R`:
+`audit_globals()` returns a 3-element list of names CRAN flagged:
+
+- `globalVariables` - undeclared variables that need a
+  `utils::globalVariables()` declaration.
+- `functions` - external functions that need an `@importFrom` line.
+- `operators` - NSE tokens, data.table / rlang pronouns (`:=`,
+  `.SD`, `.N`, `.data`, `!!`, ...) that also need an `@importFrom`
+  rather than a `globalVariables()` entry.
+
+`fix_globals(write = TRUE)` writes the `globalVariables` set into
+`R/globals.R` (merging with whatever names that file already
+declares - the freshly detected names are added on top of the
+existing ones, deduplicated). The operators section is printed on
+stdout so you wire each one into a roxygen `@importFrom` block by
+hand:
 
 ```{r}
 audit_globals(pkg, checks = chk)
 fix_globals(pkg, checks = chk, write = TRUE)
 ```
 
-Without `write = TRUE`, `fix_globals()` only prints the
-`utils::globalVariables(...)` block to copy-paste.
+When a token is exported by more than one candidate package
+(e.g. `:=` is exported by both data.table and rlang), every
+candidate is listed and you pick one consciously - no silent
+guessing.
+
+Without `write = TRUE`, `fix_globals()` only prints both blocks to
+copy-paste.
 
 ### Missing roxygen tags
 
@@ -159,6 +180,41 @@ The skeleton is editable: you fill in the description / source /
 column-by-column comments by hand, then re-run
 `devtools::document()`.
 
+### Old-style `inst/CITATION`
+
+`audit_citation()` parses `inst/CITATION` statically (no `eval()`)
+and surfaces every call to `personList()`, `as.personList()` or
+`citEntry()` that CRAN rejects on submission with
+`Package CITATION file contains call(s) to old-style ...`. It
+returns a tibble with `call`, `line` and a one-line `suggestion`
+for the modern equivalent (`c()` on `person()` objects;
+`bibentry()` instead of `citEntry()`):
+
+```{r}
+audit_citation(pkg)
+```
+
+Read-only - rewriting a CITATION file usually needs editorial
+judgment, so there is no automated `fix_citation()`.
+
+### `\dontrun{}` blocks in examples
+
+CRAN policy is that `\dontrun{}` should only wrap example code
+that genuinely cannot be executed (missing API key, missing system
+dependency, side effect on the user's filespace). Otherwise prefer
+`\donttest{}`, which still gets exercised by
+`R CMD check --run-donttest` but is skipped by default.
+
+`audit_dontrun()` walks `man/*.Rd` line-by-line and surfaces every
+`\dontrun{}` opener (commented-out `% \dontrun{` mentions are
+ignored), with the source Rd file, the documented topic, the line
+number and a one-line suggestion. Read-only - the call is your
+review checklist:
+
+```{r}
+audit_dontrun(pkg)
+```
+
 ## Minimal end-to-end on a fake package
 
 `create_example_pkg()` builds a fake package that deliberately trips
@@ -175,6 +231,8 @@ chk <- rcmdcheck::rcmdcheck(pkg, args = "--as-cran")
 audit_tags(pkg)             # @return / @noRd issues
 audit_ascii(pkg)             # accents in comments / strings
 audit_dataset_doc(pkg)       # data/demo_dataset.rda has no doc
+audit_citation(pkg)          # old-style personList() / citEntry()
+audit_dontrun(pkg)           # \dontrun{} blocks in examples
 audit_globals(pkg, checks = chk)
 
 fix_globals(pkg, checks = chk, write = TRUE)


### PR DESCRIPTION
## Summary

Doc-only sync between `vignettes/auditing-an-r-package.Rmd` + README and the actual `audit_*()` surface on main after #110 (operators), #111 (audit_citation), #113 (audit_dontrun) merged. No code change.

### `vignettes/auditing-an-r-package.Rmd`

- Fix outright wrong claim: `audit_globals()` now returns a **3-element** list (`globalVariables`, `functions`, `operators`), not 2. Spell out the operators bucket (`:=`, `.SD`, `.data`, `!!`, ...) and the ambiguous-source rule (`:=` is exported by both data.table and rlang -> user picks one consciously, no silent guessing).
- Add `audit_citation()` and `audit_dontrun()` rows to the needs-`R CMD check` table, with their actual mechanism (static parse / line-by-line scan).
- Add per-issue cheatsheet sections for old-style `inst/CITATION` and `\dontrun{}` blocks.
- Mention the merge-with-existing behavior of `fix_globals(write = TRUE)` introduced in #108 (was silently overwriting before).
- Append `audit_citation()` + `audit_dontrun()` to the TL;DR audit script and to the minimal end-to-end demo.

### `README.Rmd` / `README.md`

- Add `audit_dontrun()` to the API table (`audit_citation()` was already there from #111).
- Add `audit_citation()` + `audit_dontrun()` to the Quick start static audits block.

## Test plan

- [ ] CI green on main (no code change).
- [ ] pkgdown re-renders cleanly with the new sections.
- [ ] Visually inspect the new vignette page on the pkgdown deploy.