### PR TITLE
fix(test): make RCE-guard test parseable on Windows

### DIFF
--- a/tests/testthat/test-fix-globals-merge.R
+++ b/tests/testthat/test-fix-globals-merge.R
@@ -148,11 +148,16 @@ test_that("extract_existing_globals does NOT execute side effects from globals.R
   marker <- tempfile("rce_marker_")
   expect_false(file.exists(marker))
 
+  # Forward slashes only: the path is embedded as a literal R
+  # string, and Windows backslashes would clash with R string
+  # escapes (\U unicode, \R bell, \a alert).
+  marker_in_src <- gsub("\\\\", "/", marker, fixed = FALSE)
+
   globals_path <- tempfile(fileext = ".R")
   writeLines(
     sprintf(
-      'utils::globalVariables(c(if (file.create(%s)) "leaked" else "ok", "real_var"))',
-      shQuote(marker)
+      'utils::globalVariables(c(if (file.create("%s")) "leaked" else "ok", "real_var"))',
+      marker_in_src
     ),
     globals_path
   )


### PR DESCRIPTION
## Summary

The Windows R-CMD-check matrix has been failing on `main` since #108 merged. Root cause: the RCE-guard test in `test-fix-globals-merge.R` embeds a `tempfile()` path as a literal R string, but on Windows that path uses backslashes (\`C:\Users\runneradmin\...\`) and \`shQuote()\` wraps it in double quotes. The resulting R source contains segments like \`\U\`, \`\R\`, \`\a\` that are real R string escapes (\`\Uxxxxxxxx\` unicode, \`\R\` bell, \`\a\` alert), so \`parse()\` aborts with \`'\U' used without hex digits\` before any global is collected.

\`extract_existing_globals()\` catches the parse error via \`tryCatch\` and returns \`character(0)\`. The RCE-guard assertion (\`file.create\` must not run) still passes by accident, but the second assertion (\`"real_var" %in% result\`) fails because the result is empty.

The fix converts backslashes to forward slashes before embedding the path. R's file APIs accept forward slashes on every supported platform, including Windows.

## Verification

Reproduced locally with a hand-crafted Windows-style fixture:

```
> parse(text = 'utils::globalVariables(c(if (file.create("C:\\Users\\runner\\rce_marker_x")) "leaked" else "ok", "real_var"))')
Error: '\U' used without hex digits in character string
```

After the fix:

```
> parse(text = 'utils::globalVariables(c(if (file.create("C:/Users/runner/rce_marker_x")) "leaked" else "ok", "real_var"))')
expression(utils::globalVariables(c(if (file.create("C:/Users/runner/rce_marker_x")) "leaked" else "ok", "real_var")))
```

## Test plan

- [x] Linux test still passes (\`testthat::test_file('tests/testthat/test-fix-globals-merge.R')\`).
- [ ] Windows R-CMD-check passes on CI.