### PR TITLE
chore: strip em-dashes / en-dashes from the project

### DIFF
--- a/R/asciify_helpers.R
+++ b/R/asciify_helpers.R
@@ -336,7 +336,7 @@ char_right <- function(line, from) {
 #'
 #' @param path path to a file. Suffixes `.R`, `.r`, `.Rmd`, `.qmd` are
 #'   handled as R source. `.Rnw` (Sweave) and any other suffix are
-#'   scanned read-only — Sweave's `<<>>= ... @` chunk syntax is not
+#'   scanned read-only - Sweave's `<<>>= ... @` chunk syntax is not
 #'   handled by the rewriter.
 #' @inheritParams asciify_r_source
 #' @param dry_run logical. If `TRUE`, report what would change but do not

--- a/R/audit_citation.R
+++ b/R/audit_citation.R
@@ -74,7 +74,7 @@ audit_citation <- function(pkg = ".") {
     suggestion = character(0)
   )
   # Surface a parse error as a warning rather than swallowing it
-  # silently — otherwise a syntactically broken CITATION (missing
+  # silently - otherwise a syntactically broken CITATION (missing
   # comma, unclosed paren, ...) would be reported as "no old-style
   # calls detected", which is misleading. Still return the empty
   # tibble so the caller can keep going.

--- a/R/audit_tags.R
+++ b/R/audit_tags.R
@@ -122,8 +122,8 @@ audit_tags <- function(pkg = ".") {
   ##
   ## We only keep blocks that roxygen2 will actually turn into an Rd
   ## file, i.e. blocks carrying a title. A bare-`@export` method (no
-  ## title, no description) does not generate its own Rd — it just
-  ## contributes a NAMESPACE entry — so CRAN will not ask for `\value`
+  ## title, no description) does not generate its own Rd - it just
+  ## contributes a NAMESPACE entry - so CRAN will not ask for `\value`
   ## on it and we must not flag it.
   func_classes <- c("function", "s3generic", "s3method")
   block_makes_rd <- function(b) {
@@ -135,7 +135,7 @@ audit_tags <- function(pkg = ".") {
     # or it joins an existing Rd via @rdname / @describeIn, or it sets
     # the Rd name explicitly via @name. A bare-`@export` block (no
     # title, no @rdname, no @name) is namespace-only and produces no
-    # Rd, so CRAN never asks for `\value` on it — flagging it would be
+    # Rd, so CRAN never asks for `\value` on it - flagging it would be
     # a false positive.
     # block_has_tags() is vectorised in `tags` and reduces internally
     # via any(); the surrounding any() here is defensive in case a
@@ -265,7 +265,7 @@ audit_tags <- function(pkg = ".") {
 
   # Pull `@return` values from topic-only blocks (`#' @name foo \n NULL`) so
   # aliases that resolve to them via `@rdname` are not flagged as missing
-  # (#82). Topic blocks themselves are not surfaced in the final output —
+  # (#82). Topic blocks themselves are not surfaced in the final output -
   # they only feed the alias propagation below.
   topic_returns <- topic_block_returns(res_topic_only)
   # Join with itself to find common rdname

--- a/dev/SUIVI_ASCIIFY.md
+++ b/dev/SUIVI_ASCIIFY.md
@@ -1,4 +1,4 @@
-# `asciify_*` — passe `feat/asciify-pkg`
+# `asciify_*` - passe `feat/asciify-pkg`
 
 Inspiré de [`dreamRs/prefixer`](https://github.com/dreamRs/prefixer)
 (`escape_unicode_script`, `show_nonascii_file`) mais corrigé pour
@@ -8,7 +8,7 @@ respecter la matrice CRAN au lieu d'échapper aveuglément tout le fichier.
 
 | Endroit | Règle CRAN | Stratégie appliquée |
 |---|---|---|
-| String literals (`"déjà"`) | NOTE *non-ASCII characters in code* | `\uXXXX` (escape) — sémantique préservée |
+| String literals (`"déjà"`) | NOTE *non-ASCII characters in code* | `\uXXXX` (escape) - sémantique préservée |
 | Commentaires R / roxygen (`# été`, `#' été`) | NOTE | translittération `Latin-ASCII` (`é` → `e`) |
 | Identifiants (`maFonçtion`) | WARNING bloquant | **refus**, ne touche pas (renommer = breaking) |
 | `man/*.Rd` | utilise `\enc{}{}` | hors scope (regénéré par roxygen) |
@@ -31,7 +31,7 @@ respecter la matrice CRAN au lieu d'échapper aveuglément tout le fichier.
   C'est ce que CRAN veut.
 * **`escape`** : tout en `\uXXXX`. Sûr pour des strings, illisible pour
   des commentaires (les `é` ne seraient pas interprétés dans un
-  commentaire — c'est juste 6 caractères ASCII bizarres).
+  commentaire - c'est juste 6 caractères ASCII bizarres).
 * **`translit`** : tout via `Latin-ASCII`. Casse le sens des chaînes
   (`"déjà"` → `"deja"`). À utiliser quand l'utilisateur sait ce qu'il
   fait.
@@ -54,7 +54,7 @@ respecter la matrice CRAN au lieu d'échapper aveuglément tout le fichier.
 2. **`escape_str_const(text)` : on n'escape que le contenu** entre les
    délimiteurs `"…"` / `'…'`. `stringi::stri_escape_unicode()`
    échapperait les guillemets eux-mêmes et ferait sortir
-   `\"déjà\"` — du R cassé. Helper `escape_chars_only()`
+   `\"déjà\"` - du R cassé. Helper `escape_chars_only()`
    réimplémente l'escape en ne touchant que les *caractères* non-ASCII.
    Les raw strings R 4.0 (`r"(...)"`, `r"[...]"`, etc.) sont détectées
    séparément.
@@ -75,7 +75,7 @@ respecter la matrice CRAN au lieu d'échapper aveuglément tout le fichier.
 |---|---|---|
 | Identifiant non-ASCII | refus (par défaut) | renommer un export = breaking |
 | Rd écrits à la main (sans roxygen) | hors scope | majorité des packages utilisent roxygen ; rajouter `\enc{}{}` proprement = scanner Rd-syntax-aware |
-| Vignettes Rnw (Sweave) | non supporté en réécriture — les chunks `<<>>= ... @` ne matchent pas le regex knitr utilisé. Routé en lecture seule (count de chars non-ASCII), pas de rewrite. |
+| Vignettes Rnw (Sweave) | non supporté en réécriture - les chunks `<<>>= ... @` ne matchent pas le regex knitr utilisé. Routé en lecture seule (count de chars non-ASCII), pas de rewrite. |
 | Fichiers > `size_limit` (500 ko) dans `find_nonascii_files()` | ignorés | safety net, blob accidentel |
 | Encodage source ≠ UTF-8 | `readLines(encoding = "UTF-8")` | suppose UTF-8 d'entrée ; à élargir si besoin via paramètre |
 

--- a/dev/SUIVI_ISSUES.md
+++ b/dev/SUIVI_ISSUES.md
@@ -1,16 +1,16 @@
-# Suivi des issues — passe `fix/multiple-issues`
+# Suivi des issues - passe `fix/multiple-issues`
 
 Méthodologie : pour chaque issue, un test unitaire qui **plante d'abord**,
 puis le correctif minimal qui le fait passer, puis un commit.
 
 ## Issues traitées
 
-### #81 — Support `@returns`
+### #81 - Support `@returns`
 roxygen2 ≥ 7.2 accepte `@returns` comme alias de `@return`. `find_missing_tags()`
 ne reconnaissait que `@return`, donc une fonction documentée avec `@returns`
 était signalée comme manquant le tag.
 
-- **Fichier de test** : `tests/testthat/test-returns_alias.R` — paquet
+- **Fichier de test** : `tests/testthat/test-returns_alias.R` - paquet
   jetable avec deux fonctions, l'une `@returns`, l'autre `@return` ; les
   deux doivent être marquées `ok`.
 - **Fix** : helper interne `block_has_return_tag()` qui appelle
@@ -18,7 +18,7 @@ ne reconnaissait que `@return`, donc une fonction documentée avec `@returns`
   `block_get_return_value()` qui essaie les deux tags.
 - **Commit** : `fix(find_missing_tags): accept @returns and inherited returns (#81, #84)`
 
-### #84 — `@inherit X return` ignoré
+### #84 - `@inherit X return` ignoré
 Une fonction documentée avec `#' @inherit foo return` est signalée comme
 sans `@return`, alors que le `.Rd` généré par `devtools::document()` est
 correct.
@@ -30,14 +30,14 @@ correct.
   ce qui couvre le cas d'`@inherit X` seul).
 - **Commit** : voir #81 (commit unique).
 
-### #82 — Faux positif sur `@rdname` quand le canonique documente NULL
+### #82 - Faux positif sur `@rdname` quand le canonique documente NULL
 `#' @name foo \n NULL` est un *topic block* qui définit `@return` pour la
 famille de fonctions liée par `@rdname`. checkhelper ne regardait que les
 blocks de classe `function`, donc le `@return` du topic était invisible
 pour la propagation, et toute fonction qui faisait `@rdname foo` était
 signalée à tort.
 
-- **Test** : `tests/testthat/test-rdname_topic_block.R` — reproduction
+- **Test** : `tests/testthat/test-rdname_topic_block.R` - reproduction
   fidèle du reprex de l'issue.
 - **Fix** : collecte des `res_topic_only` (blocks dont l'objet n'est pas
   `function`/`package`/`data`), construction d'un dictionnaire
@@ -46,34 +46,34 @@ signalée à tort.
   par `set_correct_return_to_alias()`.
 - **Commit** : `fix(find_missing_tags): pull returns from topic-only blocks via @rdname (#82)`
 
-### #18 — Plantage sur un paquet vide
+### #18 - Plantage sur un paquet vide
 `find_missing_tags()` plantait avec `objet 'rdname_value' introuvable`
 sur un paquet sans fichiers `R/`, parce que `unlist(list())` renvoie
 `NULL` et `tibble()` jette les colonnes NULL.
 
-- **Test** : `tests/testthat/test-empty_package.R` — paquet créé puis
+- **Test** : `tests/testthat/test-empty_package.R` - paquet créé puis
   `R/` vidé ; `find_missing_tags()` doit renvoyer une liste à 3 entrées,
   `functions` ayant 0 ligne.
 - **Fix** : `as.character(unlist(...))` / `as.logical(unlist(...))` autour
   de chaque colonne, et `seq_len(n())` pour l'`id` au lieu de `1:n()`.
 - **Commit** : `fix(find_missing_tags): handle empty packages without dplyr error (#18)`
 
-### #19 — `overwrite` dans `use_data_doc()`
+### #19 - `overwrite` dans `use_data_doc()`
 Demande utilisateur : pouvoir mettre à jour la doc de données après
 re-génération sans clobber les éditions manuelles.
 
-- **Test** : `tests/testthat/test-use_data_doc_overwrite.R` — cas
+- **Test** : `tests/testthat/test-use_data_doc_overwrite.R` - cas
   comportemental : 1er appel → fichier créé ; 2ᵉ appel → erreur
   explicite ; 3ᵉ appel avec `overwrite = TRUE` → contenu remplacé.
 - **Fix** : nouvel argument `overwrite = FALSE`, garde-fou
   `if (file.exists(path) && !isTRUE(overwrite)) stop(...)`.
 - **Commit** : `feat(use_data_doc): add overwrite parameter (#19)`
 
-### #79 — `check_as_cran()` ne respecte pas `repos`
+### #79 - `check_as_cran()` ne respecte pas `repos`
 `withr::with_options(list(repos = ...), check_as_cran())` n'avait aucun
 effet car la fonction ne propageait pas l'option.
 
-- **Test** : `tests/testthat/test-check_as_cran_args.R` — assertion sur
+- **Test** : `tests/testthat/test-check_as_cran_args.R` - assertion sur
   l'API formelle (`repos` doit faire partie des arguments) et sur le
   nouveau défaut de `check_output` (#85).
 - **Fix** : nouvel argument `repos = getOption("repos")`, fallback vers
@@ -81,22 +81,22 @@ effet car la fonction ne propageait pas l'option.
   `withr::with_options(list(repos = repos), the_check(...))`.
 - **Commit** : `feat(check_as_cran): honour repos option + default check_output near pkg (#79, #85)`
 
-### #85 — Défaut de `check_output` dans `check_as_cran()`
+### #85 - Défaut de `check_output` dans `check_as_cran()`
 Le défaut `tempfile("check_output")` rendait les logs introuvables après
 la session. L'utilisateur voulait un dossier à côté du paquet.
 
-- **Test** : couvert par `test-check_as_cran_args.R` — le défaut doit
+- **Test** : couvert par `test-check_as_cran_args.R` - le défaut doit
   référencer `pkg`, pas `tempfile`.
 - **Fix** : `check_output = file.path(dirname(normalizePath(pkg)), "check")`.
 - **Commit** : voir #79 (commit unique).
 
-### #77 — `find_missing_tags()` pollue l'environnement utilisateur
+### #77 - `find_missing_tags()` pollue l'environnement utilisateur
 La fonction se termine par `roxygen2::roxygenise(package.dir)` qui
 appelle `pkgload::load_all()`. Le paquet cible reste **attaché** sur le
 `search()` et chargé dans `loadedNamespaces()` après le retour, et les
 fonctions du paquet (y compris non exportées) deviennent visibles.
 
-- **Test** : `tests/testthat/test-env_pollution.R` — assert que
+- **Test** : `tests/testthat/test-env_pollution.R` - assert que
   `package:pkg.leak` n'est ni dans `search()` ni dans
   `loadedNamespaces()` après l'appel.
 - **Fix** : snapshot `loadedNamespaces()` + `search()` à l'entrée,
@@ -106,21 +106,21 @@ fonctions du paquet (y compris non exportées) deviennent visibles.
   Ajout de `pkgload` aux `Imports`.
 - **Commit** : `fix(find_missing_tags): unload target package on exit (#77)`
 
-### #93 — `Error in srcrefs[[1L]]: subscript out of bounds` sur `@examplesIf`
+### #93 - `Error in srcrefs[[1L]]: subscript out of bounds` sur `@examplesIf`
 Bug environnemental dans `pkgload::run_example()` (ancien R / ancien
 pkgload, exemple `@examplesIf` dont le corps tombe entièrement dans
 `\donttest{}`). Pas reproductible localement avec R 4.5 + pkgload
 récent. Le fix est défensif côté checkhelper plutôt que pourchasser
 l'upstream :
 
-- **Test** : `tests/testthat/test-check_clean_userspace_robust.R` —
+- **Test** : `tests/testthat/test-check_clean_userspace_robust.R` -
   mocke `devtools::run_examples` pour lever l'erreur et vérifie que
   `.check_clean_userspace()` continue (warning + tibble valide).
 - **Fix** : `tryCatch()` autour de `devtools::run_examples()` dans
   `R/audit_userspace.R`, message clair, skip de la passe examples,
   continuation sur les passes suivantes.
 
-### #54 — Test `check_clean_userspace` brittle / non testable Windows
+### #54 - Test `check_clean_userspace` brittle / non testable Windows
 La cascade `nrow == 5/6/11` dans `tests/testthat/test-check_clean_userspace.R`
 forçait à `skip_on_os("windows", "mac")` car les artefacts laissés par
 `R CMD check` varient par OS.
@@ -129,7 +129,7 @@ forçait à `skip_on_os("windows", "mac")` car les artefacts laissés par
   `problem` dans des ensembles connus, les deux fuites seedées sont
   retrouvées). Plus de `skip_on_os` : le test tourne sur tous les OS.
 
-### #92 — `find_missing_tags()` rate les S3 (générique + méthode auto-doc)
+### #92 - `find_missing_tags()` rate les S3 (générique + méthode auto-doc)
 Pour le pattern S3 (`f <- function(...) UseMethod("f")` + `f.classe <-`),
 roxygen2 attribue `class(b$object)[1] = "s3generic"` au générique et
 `"s3method"` à la méthode. Le filtre historique
@@ -139,10 +139,10 @@ encore `\value` sur `strand_chr.Rd` (générique) ou
 `dim.gggenomes_layout.Rd` (méthode auto-documentée), comme rapporté pour
 [`gggenomes`](https://github.com/thackl/gggenomes/tree/missing-value-tags).
 
-- **Test** : `tests/testthat/test-s3_missing_value.R` — trois cas :
+- **Test** : `tests/testthat/test-s3_missing_value.R` - trois cas :
   générique sans `@return` (doit être flaggé), méthode avec son propre
   Rd et sans `@return` (doit être flaggé), méthode `@export` nu sans
-  doc (ne doit **pas** être flaggée — pas de Rd).
+  doc (ne doit **pas** être flaggée - pas de Rd).
 - **Fix** : helper interne `block_makes_rd()` qui élargit le filtre à
   `c("function", "s3generic", "s3method")` puis ne garde que les blocs
   qui produisent réellement un fichier Rd (`title` / `rdname` /
@@ -158,5 +158,5 @@ encore `\value` sur `strand_chr.Rd` (générique) ou
 
 ## CI
 
-Le repo a déjà un workflow `R-CMD-check.yaml` opérationnel — la PR le
+Le repo a déjà un workflow `R-CMD-check.yaml` opérationnel - la PR le
 déclenchera automatiquement.

--- a/man/asciify_file.Rd
+++ b/man/asciify_file.Rd
@@ -14,7 +14,7 @@ asciify_file(
 \arguments{
 \item{path}{path to a file. Suffixes \code{.R}, \code{.r}, \code{.Rmd}, \code{.qmd} are
 handled as R source. \code{.Rnw} (Sweave) and any other suffix are
-scanned read-only — Sweave's \verb{<<>>= ... @} chunk syntax is not
+scanned read-only - Sweave's \verb{<<>>= ... @} chunk syntax is not
 handled by the rewriter.}
 
 \item{strategy}{one of:

--- a/tests/testthat/test-audit-globals.R
+++ b/tests/testthat/test-audit-globals.R
@@ -14,7 +14,7 @@ test_that("audit_globals() returns either NULL or a list with globalVariables / 
     expect_type(out, "list")
     expect_named(out, c("globalVariables", "functions", "operators"))
   } else {
-    succeed("audit_globals returned NULL — package had no notes")
+    succeed("audit_globals returned NULL - package had no notes")
   }
 })
 

--- a/tests/testthat/test-check_as_cran_args.R
+++ b/tests/testthat/test-check_as_cran_args.R
@@ -1,5 +1,5 @@
 test_that("check_as_cran() exposes a `repos` argument and a sensible default check_output (#79, #85)", {
-  # We only assert on the formal API of the function — running an actual
+  # We only assert on the formal API of the function - running an actual
   # CRAN-style check against a fake package is heavy and is already
   # covered (and flaky-skipped) by tests/testthat/test-check_as_cran.R.
   fmls <- formals(check_as_cran)
@@ -9,7 +9,7 @@ test_that("check_as_cran() exposes a `repos` argument and a sensible default che
   # check_output default should resolve to a directory adjacent to `pkg`,
   # not the session tempdir, so the user can find their logs (#85).
   default_out <- paste(deparse(fmls[["check_output"]]), collapse = " ")
-  # We accept either dirname(pkg) or file.path(pkg, …) — anything that
+  # We accept either dirname(pkg) or file.path(pkg, …) - anything that
   # references `pkg` works. The point is: not a session-only tempfile.
   expect_true(grepl("pkg", default_out, fixed = TRUE),
     info = "default check_output should reference the package path")

--- a/tests/testthat/test-check_clean_userspace_robust.R
+++ b/tests/testthat/test-check_clean_userspace_robust.R
@@ -1,7 +1,7 @@
 # Regression tests for #93: when devtools::run_examples() crashes deep in
 # pkgload (`srcrefs[[1L]]: subscript out of bounds` on @examplesIf with an
 # empty post-strip body, on older R + pkgload), check_clean_userspace()
-# must not abort the whole audit — it must skip the examples step,
+# must not abort the whole audit - it must skip the examples step,
 # surface a clear warning, and STILL run unit tests / full check /
 # vignettes. Plus also call check_clean_userspace internal use the
 # qualified path (checkhelper:::.check_clean_userspace) so the mock

--- a/tests/testthat/test-empty_package.R
+++ b/tests/testthat/test-empty_package.R
@@ -5,7 +5,7 @@ test_that("find_missing_tags() handles a package with no R/ functions (#18)", {
 
   usethis::create_package(file.path(pkg_path, "pkg.empty"), open = FALSE)
   pkg_dir <- file.path(pkg_path, "pkg.empty")
-  # Empty R/ — no functions to document.
+  # Empty R/ - no functions to document.
   unlink(list.files(file.path(pkg_dir, "R"), full.names = TRUE))
 
   # Should not raise.

--- a/tests/testthat/test-fix-globals-light-check.R
+++ b/tests/testthat/test-fix-globals-light-check.R
@@ -7,7 +7,7 @@
 # (`* checking R code for possible problems`). They do NOT depend on
 # building vignettes, running tests, running examples, or rendering
 # the manual. The historical default (`rcmdcheck(path)` with no args)
-# triggered all four heavy phases for nothing — on a package with
+# triggered all four heavy phases for nothing - on a package with
 # vignettes, that's minutes of wasted time per call.
 #
 # The contract this test pins down:

--- a/tests/testthat/test-fix-globals-merge.R
+++ b/tests/testthat/test-fix-globals-merge.R
@@ -4,7 +4,7 @@
 # Why: R CMD check filters out names already covered by an existing
 # globalVariables() call. So the second time fix_globals() runs on a
 # package that already has a curated globals.R, the notes only list
-# the *new* uncovered names — overwriting the file would erase the
+# the *new* uncovered names - overwriting the file would erase the
 # previously-declared names and re-flag them on the next check.
 # That's a circular game the user can't win.
 

--- a/tests/testthat/test-fix-globals-operators.R
+++ b/tests/testthat/test-fix-globals-operators.R
@@ -1,7 +1,7 @@
 # Regression test: fix_globals() must not glue NSE operators / data.table
 # pronouns / rlang quasiquotation tokens into the
 # `utils::globalVariables(c(...))` block. Those are not undeclared
-# variables — they are exports from another package and the right fix
+# variables - they are exports from another package and the right fix
 # is `@importFrom`. See user request: `:=`, `.SD`, `.N`, `.I`, `.GRP`,
 # `.BY`, `.EACHI` (data.table) and `.data`, `.env`, `!!`, `!!!`
 # (rlang).
@@ -98,7 +98,7 @@ test_that("ambiguous source (`:=` from data.table OR rlang) lists both candidate
     message = FALSE
   )
 
-  # Both candidate packages must be visible — never silently pick one.
+  # Both candidate packages must be visible - never silently pick one.
   expect_match(printed$liste_operators, "data.table", fixed = TRUE)
   expect_match(printed$liste_operators, "rlang", fixed = TRUE)
 })

--- a/tests/testthat/test-namespace-shape.R
+++ b/tests/testthat/test-namespace-shape.R
@@ -1,11 +1,11 @@
 ## test-namespace-shape.R
 ##
 ## Lock the public API surface. Any add / remove / rename of an exported
-## name must be accompanied by an update to the list below — the test fails
+## name must be accompanied by an update to the list below - the test fails
 ## otherwise.
 
 expected_exports <- c(
-  ## Public façades — audit_*
+  ## Public façades - audit_*
   "audit_ascii",
   "audit_check",
   "audit_citation",
@@ -16,7 +16,7 @@ expected_exports <- c(
   "audit_tags",
   "audit_userspace",
 
-  ## Public façades — fix_*
+  ## Public façades - fix_*
   "fix_ascii",
   "fix_dataset_doc",
   "fix_globals",

--- a/tests/testthat/test-use_data_doc_overwrite.R
+++ b/tests/testthat/test-use_data_doc_overwrite.R
@@ -6,7 +6,7 @@ test_that("use_data_doc() refuses to overwrite by default and respects overwrite
   pkg_dir <- file.path(pkg_path, "pkg.docover")
 
   # Create a fake "my_data.rda" so get_data_info() can read its dimensions.
-  # We don't need realistic data — use_data_doc() only needs the file to exist.
+  # We don't need realistic data - use_data_doc() only needs the file to exist.
   data_dir <- file.path(pkg_dir, "data")
   dir.create(data_dir, showWarnings = FALSE)
   my_data <- data.frame(a = 1:3, b = letters[1:3])


### PR DESCRIPTION
## Summary

Hard rule: never emit U+2014 em-dash or U+2013 en-dash anywhere in the project (chat, commit messages, PR / release bodies, code comments, file content). Use ASCII hyphens or rewrite the sentence.

This sweep replaces every occurrence in tracked files via:

```
perl -CSD -i -pe 's/\x{2014}/-/g; s/\x{2013}/-/g' <files>
```

15 files touched, 48 substitutions. All in comments / prose / NEWS / dev notes / man pages. No test fixture relies on the literal codepoint (the asciify test set uses `—` escapes inside string literals, never bare em-dashes in source).

Drive-by: removed an accidental `.claude/worktrees/...` submodule reference that snuck into the first commit (sub-agent leftover).

## Test plan

- [x] `devtools::test()` green locally on the dash-stripped tree.
- [x] `git ls-files | xargs grep -lP '[\x{2014}\x{2013}]'` returns nothing.
- [ ] CI matrix green.