### PR TITLE
test: raise code coverage from 87.6 % to 93.3 %

### DIFF
--- a/tests/testthat/test-asciify-coverage.R
+++ b/tests/testthat/test-asciify-coverage.R
@@ -1,0 +1,139 @@
+# Coverage-targeted tests for tiny branches inside asciify_helpers.R.
+# Each block targets one or two specific zero-coverage lines.
+
+test_that("`%||%` returns the right side when the left is NULL", {
+  expect_equal(checkhelper:::`%||%`(NULL, "fallback"), "fallback")
+})
+
+test_that("`%||%` returns the left side when the left is not NULL", {
+  expect_equal(checkhelper:::`%||%`("present", "fallback"), "present")
+})
+
+test_that("find_nonascii_tokens() returns empty on empty text", {
+  res <- checkhelper:::find_nonascii_tokens("")
+  expect_equal(nrow(res), 0L)
+})
+
+test_that("find_nonascii_tokens() returns empty when parse data is empty", {
+  # A whitespace-only file parses to zero expressions, so getParseData
+  # returns an empty table.
+  res <- checkhelper:::find_nonascii_tokens("   \n\t \n")
+  expect_equal(nrow(res), 0L)
+})
+
+test_that("rewrite_nonascii_token('report' strategy) returns the text unchanged", {
+  expect_equal(
+    checkhelper:::rewrite_nonascii_token(text = "\"déjà\"", token = "STR_CONST", strategy = "report"),
+    "\"déjà\""
+  )
+})
+
+test_that("escape_chars_only() short-circuits on pure-ASCII input", {
+  expect_equal(checkhelper:::escape_chars_only("plain ascii only"), "plain ascii only")
+})
+
+test_that("escape_chars_only() handles a single-character non-ASCII string", {
+  res <- checkhelper:::escape_chars_only("é")
+  expect_match(res, "\\\\u")
+})
+
+test_that("escape_str_const() falls back to escape_chars_only on non-quoted text", {
+  # A bare identifier (no surrounding quotes, not a raw literal) takes the
+  # final fallback path.
+  res <- checkhelper:::escape_str_const("déjà")
+  expect_match(res, "\\\\u")
+  expect_false(grepl("^[\"']", res))
+})
+
+test_that("has_trailing_newline() returns FALSE on a missing or empty file", {
+  empty <- tempfile()
+  file.create(empty)
+  on.exit(unlink(empty), add = TRUE)
+  expect_false(checkhelper:::has_trailing_newline(empty))
+
+  missing_path <- tempfile()
+  expect_false(checkhelper:::has_trailing_newline(missing_path))
+})
+
+test_that("has_trailing_newline() detects a file ending with a newline", {
+  p <- tempfile()
+  writeLines("hello", p)
+  on.exit(unlink(p), add = TRUE)
+  expect_true(checkhelper:::has_trailing_newline(p))
+})
+
+test_that("write_text_preserving_eol() strips a trailing newline when asked", {
+  p <- tempfile()
+  on.exit(unlink(p), add = TRUE)
+  checkhelper:::write_text_preserving_eol(text = "hello\n", path = p, trailing_nl = FALSE)
+  bytes <- readBin(p, what = "raw", n = file.size(p))
+  expect_false(bytes[length(bytes)] == as.raw(0x0a))
+})
+
+test_that("write_text_preserving_eol() adds a trailing newline when asked", {
+  p <- tempfile()
+  on.exit(unlink(p), add = TRUE)
+  checkhelper:::write_text_preserving_eol(text = "hello", path = p, trailing_nl = TRUE)
+  bytes <- readBin(p, what = "raw", n = file.size(p))
+  expect_true(bytes[length(bytes)] == as.raw(0x0a))
+})
+
+test_that("count_nonascii_chars() returns 0 on empty input", {
+  expect_equal(checkhelper:::count_nonascii_chars(""), 0L)
+  expect_equal(checkhelper:::count_nonascii_chars(character(0)), 0L)
+})
+
+test_that("count_nonascii_chars() counts non-ASCII characters", {
+  expect_equal(checkhelper:::count_nonascii_chars("déjà"), 2L)
+})
+
+# --- More targeted helper coverage ------------------------------------------
+
+test_that("asciify_file() returns an empty payload on an empty file", {
+  empty <- tempfile(fileext = ".R")
+  file.create(empty)
+  on.exit(unlink(empty), add = TRUE)
+
+  res <- checkhelper:::asciify_file(empty)
+  expect_false(res$changed)
+  expect_equal(res$n_tokens, 0L)
+  expect_equal(res$n_chars, 0L)
+})
+
+test_that("asciify_file() leaves a non-R/Rmd/qmd file unchanged", {
+  txt <- tempfile(fileext = ".txt")
+  writeLines("plain text déjà", txt)
+  on.exit(unlink(txt), add = TRUE)
+
+  res <- checkhelper:::asciify_file(txt)
+  expect_false(res$changed)
+  # n_tokens equals n_chars for non-R files (no parsing happens).
+  expect_equal(res$n_tokens, res$n_chars)
+})
+
+test_that("asciify_r_source() handles a multi-line STR_CONST containing non-ASCII", {
+  # The multi-line STR_CONST branch (line ~287+ in asciify_r_source)
+  # rebuilds the source by stitching the surrounding context around
+  # the rewritten lines. Trigger it with a string literal that spans
+  # two lines and contains a non-ASCII codepoint.
+  src <- 'x <- "first line déjà\nsecond line"\n'
+
+  out <- checkhelper:::asciify_r_source(
+    src,
+    strategy = "escape",
+    identifiers = "skip"
+  )
+
+  expect_match(out, "\\\\u")
+  expect_true(grepl("second line", out))
+})
+
+test_that(".asciify_pkg() returns an empty frame when the package has no scannable files", {
+  pkg <- tempfile("pkg-no-files-")
+  dir.create(pkg)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  out <- suppressMessages(checkhelper:::.asciify_pkg(path = pkg))
+  expect_s3_class(out, "data.frame")
+  expect_equal(nrow(out), 0L)
+})

--- a/tests/testthat/test-audit-citation.R
+++ b/tests/testthat/test-audit-citation.R
@@ -115,3 +115,33 @@ test_that("audit_citation() reports correct line numbers for nested calls", {
   expect_true(citEntry_line == 4L)
   expect_true(personList_line >= 4L)
 })
+
+# --- Edge / coverage tests --------------------------------------------------
+
+local_pkg_with_citation <- function(citation, envir = parent.frame()) {
+  path <- tempfile("pkg-cit-")
+  dir.create(file.path(path, "inst"), recursive = TRUE)
+  writeLines(citation, file.path(path, "inst", "CITATION"))
+  withr::defer(unlink(path, recursive = TRUE), envir = envir)
+  path
+}
+
+test_that("audit_citation() warns and returns empty on a syntactically broken CITATION", {
+  pkg <- local_pkg_with_citation(c(
+    'citEntry(entry = "Manual",',
+    '  title = "no closing paren ever'
+  ))
+
+  expect_warning(
+    out <- audit_citation(pkg),
+    regexp = "Could not parse"
+  )
+  expect_equal(nrow(out), 0L)
+})
+
+test_that("audit_citation() returns empty on an empty CITATION", {
+  pkg <- local_pkg_with_citation(character(0))
+
+  out <- audit_citation(pkg)
+  expect_equal(nrow(out), 0L)
+})

--- a/tests/testthat/test-audit-dataset-doc.R
+++ b/tests/testthat/test-audit-dataset-doc.R
@@ -38,3 +38,107 @@ test_that("audit_dataset_doc() emits a cli message", {
   on.exit(unlink(path, recursive = TRUE))
   expect_message(audit_dataset_doc(path), regexp = "dataset")
 })
+
+# --- Edge / coverage tests --------------------------------------------------
+
+local_pkg_with_data <- function(rda_names = character(), r_files = list(),
+                                envir = parent.frame()) {
+  path <- tempfile("pkg-ds-")
+  dir.create(file.path(path, "data"), recursive = TRUE)
+  dir.create(file.path(path, "R"), recursive = TRUE)
+  for (nm in rda_names) {
+    x <- 1
+    save(x, file = file.path(path, "data", paste0(nm, ".rda")))
+  }
+  for (nm in names(r_files)) {
+    writeLines(r_files[[nm]], file.path(path, "R", nm))
+  }
+  withr::defer(unlink(path, recursive = TRUE), envir = envir)
+  path
+}
+
+test_that("audit_dataset_doc() returns empty tibble when data/ is missing", {
+  pkg <- tempfile("pkg-no-data-")
+  dir.create(pkg)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  out <- suppressMessages(audit_dataset_doc(pkg))
+  expect_s3_class(out, "tbl_df")
+  expect_equal(nrow(out), 0L)
+})
+
+test_that("audit_dataset_doc() returns empty tibble when data/ has no rda files", {
+  pkg <- tempfile("pkg-empty-data-")
+  dir.create(file.path(pkg, "data"), recursive = TRUE)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  out <- suppressMessages(audit_dataset_doc(pkg))
+  expect_equal(nrow(out), 0L)
+})
+
+test_that("audit_dataset_doc() handles a package without an R/ directory", {
+  pkg <- tempfile("pkg-no-r-")
+  dir.create(file.path(pkg, "data"), recursive = TRUE)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+  x <- 1
+  save(x, file = file.path(pkg, "data", "demo.rda"))
+
+  out <- suppressMessages(audit_dataset_doc(pkg))
+  expect_equal(nrow(out), 1L)
+  expect_false(out$has_doc)
+})
+
+test_that("audit_dataset_doc() detects a documented dataset via @name", {
+  pkg <- local_pkg_with_data(
+    rda_names = "demo",
+    r_files = list("demo-data.R" = c(
+      "#' Demo dataset",
+      "#'",
+      "#' @name demo",
+      "#' @format A vector.",
+      "NULL"
+    ))
+  )
+
+  out <- suppressMessages(audit_dataset_doc(pkg))
+  expect_true(out$has_doc[out$name == "demo"])
+})
+
+test_that("audit_dataset_doc() detects a documented dataset via quoted string reference", {
+  pkg <- local_pkg_with_data(
+    rda_names = "demo",
+    r_files = list("demo-data.R" = c(
+      "#' Demo dataset",
+      "#' @format A vector.",
+      '"demo"'
+    ))
+  )
+
+  out <- suppressMessages(audit_dataset_doc(pkg))
+  expect_true(out$has_doc[out$name == "demo"])
+})
+
+test_that(".get_data_info() errors when the dataset name does not exist", {
+  pkg <- local_pkg_with_data(rda_names = "demo")
+  expect_error(
+    withr::with_dir(pkg, checkhelper:::.get_data_info("nope")),
+    regexp = "not found"
+  )
+})
+
+test_that(".get_data_info() errors when multiple rda files share the same stem", {
+  # Force two rda files with the same case-insensitive stem on a
+  # case-sensitive filesystem (Linux/CI).
+  skip_on_os("windows")
+  pkg <- tempfile("pkg-dupe-")
+  dir.create(file.path(pkg, "data"), recursive = TRUE)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+  x <- 1
+  save(x, file = file.path(pkg, "data", "demo.rda"))
+  save(x, file = file.path(pkg, "data", "demo.RData"))
+
+  expect_error(
+    withr::with_dir(pkg, checkhelper:::.get_data_info("demo")),
+    regexp = "multiple files"
+  )
+})

--- a/tests/testthat/test-audit-description.R
+++ b/tests/testthat/test-audit-description.R
@@ -185,3 +185,87 @@ test_that("audit_description() does not flag the package's own name", {
 
   expect_equal(nrow(out), 0L)
 })
+
+# --- Edge / coverage tests --------------------------------------------------
+
+test_that("audit_description() warns when DESCRIPTION cannot be parsed", {
+  pkg <- tempfile("pkg-bad-desc-")
+  dir.create(pkg)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+  # Garbage DESCRIPTION: a line without `Field:` triggers
+  # "Line starting '...' is malformed!" inside read.dcf.
+  writeLines(c("not a dcf file at all", "random garbage"), file.path(pkg, "DESCRIPTION"))
+
+  expect_warning(
+    out <- suppressMessages(audit_description(pkg)),
+    regexp = "could not parse DESCRIPTION"
+  )
+  expect_equal(nrow(out), 0L)
+})
+
+test_that("audit_description() returns empty when DESCRIPTION has no Description field", {
+  pkg <- tempfile("pkg-no-desc-field-")
+  dir.create(pkg)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+  writeLines(c("Package: x", "Title: t", "Version: 0.0.0"), file.path(pkg, "DESCRIPTION"))
+
+  out <- suppressMessages(audit_description(pkg))
+  expect_equal(nrow(out), 0L)
+})
+
+test_that("audit_description() returns empty when Description field is empty", {
+  pkg <- tempfile("pkg-empty-desc-")
+  dir.create(pkg)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+  writeLines(
+    c("Package: x", "Title: t", "Version: 0.0.0", "Description: "),
+    file.path(pkg, "DESCRIPTION")
+  )
+
+  out <- suppressMessages(audit_description(pkg))
+  expect_equal(nrow(out), 0L)
+})
+
+test_that("audit_description() handles DESCRIPTION without Package field (own_name = '')", {
+  # Synthetic: read.dcf still returns a 1-row matrix without a Package column.
+  pkg <- tempfile("pkg-no-package-field-")
+  dir.create(pkg)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+  writeLines(
+    c("Title: t", "Description: Wrapper around jsonlite for parsing."),
+    file.path(pkg, "DESCRIPTION")
+  )
+
+  out <- suppressMessages(testthat::with_mocked_bindings(
+    audit_description(pkg),
+    .installed_packages = function() c("jsonlite"),
+    .package = "checkhelper"
+  ))
+  expect_equal(out$word, "jsonlite")
+})
+
+test_that(".find_unquoted_pkg_names() returns empty on punctuation-only text", {
+  empty <- checkhelper:::.find_unquoted_pkg_names(
+    description = "...!!!",
+    installed = c("jsonlite")
+  )
+  expect_equal(nrow(empty), 0L)
+})
+
+test_that(".find_unquoted_pkg_names() handles token at start and end of text", {
+  # `jsonlite` at the very start (no `before` char) and `httr` at the very
+  # end (no `after` char). Both must still be flagged.
+  out <- checkhelper:::.find_unquoted_pkg_names(
+    description = "jsonlite is faster than httr",
+    installed = c("jsonlite", "httr")
+  )
+  expect_setequal(out$word, c("jsonlite", "httr"))
+})
+
+test_that(".installed_packages() returns the real catalogue when called unmocked", {
+  out <- checkhelper:::.installed_packages()
+  expect_true(is.character(out))
+  expect_true(length(out) > 0L)
+  # checkhelper itself must be installed during the test run.
+  expect_true("checkhelper" %in% out || "testthat" %in% out)
+})

--- a/tests/testthat/test-audit-dontrun.R
+++ b/tests/testthat/test-audit-dontrun.R
@@ -135,3 +135,44 @@ test_that("audit_dontrun() ignores commented-out \\dontrun mentions", {
   out <- audit_dontrun(pkg)
   expect_equal(nrow(out), 0L)
 })
+
+# --- Edge / coverage tests --------------------------------------------------
+
+test_that("audit_dontrun() handles empty man/ directory (no Rd files)", {
+  pkg <- tempfile("pkg-empty-man-")
+  dir.create(file.path(pkg, "man"), recursive = TRUE)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  expect_message(out <- audit_dontrun(pkg), regexp = "no Rd files")
+  expect_equal(nrow(out), 0L)
+})
+
+test_that(".scan_one_rd_for_dontrun() warns and skips when readLines fails", {
+  # Passing a directory path to readLines() raises an error that the
+  # internal tryCatch must surface as a warning, then return NULL.
+  bad_path <- tempfile("bad-rd-")
+  dir.create(bad_path)
+  on.exit(unlink(bad_path, recursive = TRUE), add = TRUE)
+
+  expect_warning(
+    res <- checkhelper:::.scan_one_rd_for_dontrun(bad_path),
+    regexp = "Could not read"
+  )
+  expect_null(res)
+})
+
+test_that(".scan_one_rd_for_dontrun() returns NULL on empty file", {
+  empty_rd <- tempfile(fileext = ".Rd")
+  file.create(empty_rd)
+  on.exit(unlink(empty_rd), add = TRUE)
+
+  expect_null(checkhelper:::.scan_one_rd_for_dontrun(empty_rd))
+})
+
+test_that(".topic_from_rd() falls back to basename when \\name is missing", {
+  topic <- checkhelper:::.topic_from_rd(
+    lines = c("\\title{x}", "\\examples{}"),
+    fallback = "my_fallback"
+  )
+  expect_equal(topic, "my_fallback")
+})

--- a/tests/testthat/test-audit-globals-coverage.R
+++ b/tests/testthat/test-audit-globals-coverage.R
@@ -1,0 +1,208 @@
+# Coverage-targeted tests for branches of audit_globals.R that aren't
+# exercised by the existing suite. Each block targets a specific set
+# of zero-coverage lines reported by covr::zero_coverage().
+
+# audit_globals(): NULL path when the checker returns nothing -----------------
+
+test_that("audit_globals() returns NULL with a verbose message when no globals", {
+  expect_message(
+    out <- testthat::with_mocked_bindings(
+      audit_globals("/tmp/anywhere"),
+      .get_no_visible = function(...) NULL,
+      .package = "checkhelper"
+    ),
+    regexp = "no global notes"
+  )
+  expect_null(out)
+})
+
+# fix_globals(write = FALSE): print path -------------------------------------
+
+test_that("fix_globals(write = FALSE) prints both blocks and operators block", {
+  globals <- list(
+    globalVariables = tibble::tibble(fun = "f", variable = "var_a"),
+    functions = tibble::tibble(fun = "f", variable = "extern_fn", proposed = "ns::extern_fn"),
+    operators = tibble::tibble(fun = "f", variable = ":=", source_pkg = "data.table;rlang")
+  )
+
+  res <- testthat::with_mocked_bindings(
+    suppressMessages(fix_globals("/tmp/anywhere", write = FALSE)),
+    .get_no_visible = function(...) globals,
+    .package = "checkhelper"
+  )
+
+  expect_null(res)
+})
+
+# fix_globals(write = TRUE) without an R/ directory --------------------------
+
+test_that("fix_globals(write = TRUE) creates R/ when it does not exist", {
+  pkg <- tempfile("pkg-no-r-")
+  dir.create(pkg)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+  expect_false(dir.exists(file.path(pkg, "R")))
+
+  globals <- list(
+    globalVariables = tibble::tibble(fun = "f", variable = "first_var"),
+    functions = tibble::tibble(
+      fun = character(0), variable = character(0), proposed = character(0)
+    )
+  )
+
+  res <- testthat::with_mocked_bindings(
+    suppressMessages(fix_globals(pkg, write = TRUE)),
+    .get_no_visible = function(...) globals,
+    .package = "checkhelper"
+  )
+
+  expect_true(dir.exists(file.path(pkg, "R")))
+  expect_true(file.exists(file.path(pkg, "R", "globals.R")))
+  expect_equal(normalizePath(res), normalizePath(file.path(pkg, "R", "globals.R")))
+})
+
+# fix_globals(write = TRUE) with operators -----------------------------------
+
+test_that("fix_globals(write = TRUE) prints the operators block and informs", {
+  pkg <- tempfile("pkg-ops-")
+  dir.create(file.path(pkg, "R"), recursive = TRUE)
+  on.exit(unlink(pkg, recursive = TRUE), add = TRUE)
+
+  globals <- list(
+    globalVariables = tibble::tibble(fun = "f", variable = "var_a"),
+    functions = tibble::tibble(
+      fun = character(0), variable = character(0), proposed = character(0)
+    ),
+    operators = tibble::tibble(fun = "f", variable = ":=", source_pkg = "data.table;rlang")
+  )
+
+  expect_message(
+    testthat::with_mocked_bindings(
+      fix_globals(pkg, write = TRUE),
+      .get_no_visible = function(...) globals,
+      .package = "checkhelper"
+    ),
+    regexp = "operators / pronouns above"
+  )
+})
+
+# fix_globals(): NULL globals path -------------------------------------------
+
+test_that("fix_globals() returns invisibly with no-op message when no globals", {
+  expect_message(
+    res <- testthat::with_mocked_bindings(
+      fix_globals("/tmp/anywhere"),
+      .get_no_visible = function(...) NULL,
+      .package = "checkhelper"
+    ),
+    regexp = "no globals to declare"
+  )
+  expect_null(res)
+})
+
+# extract_existing_globals(): parse-error path -------------------------------
+
+test_that("extract_existing_globals() returns character(0) when globals.R does not parse", {
+  globals_path <- tempfile(fileext = ".R")
+  writeLines("this is ( not valid R", globals_path)
+  on.exit(unlink(globals_path), add = TRUE)
+
+  res <- checkhelper:::extract_existing_globals(globals_path)
+  expect_equal(res, character(0))
+})
+
+# extract_existing_globals(): skips non-globalVariables calls ----------------
+
+test_that("extract_existing_globals() skips calls that are not globalVariables()", {
+  globals_path <- tempfile(fileext = ".R")
+  writeLines(
+    c(
+      'message("hello")',
+      'x <- 1 + 1',
+      'utils::globalVariables(c("real_var"))'
+    ),
+    globals_path
+  )
+  on.exit(unlink(globals_path), add = TRUE)
+
+  res <- checkhelper:::extract_existing_globals(globals_path)
+  expect_equal(res, "real_var")
+})
+
+# is_globalVariables_call(): every branch ------------------------------------
+
+test_that("is_globalVariables_call() returns FALSE on non-call inputs", {
+  expect_false(checkhelper:::is_globalVariables_call(quote(x)))
+  expect_false(checkhelper:::is_globalVariables_call(42))
+  expect_false(checkhelper:::is_globalVariables_call("string"))
+})
+
+test_that("is_globalVariables_call() recognises both bare and utils:: forms", {
+  expect_true(checkhelper:::is_globalVariables_call(quote(globalVariables(c("x")))))
+  expect_true(checkhelper:::is_globalVariables_call(quote(utils::globalVariables(c("x")))))
+})
+
+test_that("is_globalVariables_call() returns FALSE for other namespaced calls", {
+  expect_false(checkhelper:::is_globalVariables_call(quote(other::fn(x))))
+  expect_false(checkhelper:::is_globalVariables_call(quote(utils::other_fn(x))))
+  expect_false(checkhelper:::is_globalVariables_call(quote(some_fn(x))))
+})
+
+# .print_globals(): malformed input ------------------------------------------
+
+test_that(".print_globals() errors on a malformed globals list", {
+  expect_error(
+    checkhelper:::.print_globals(globals = list()),
+    regexp = "globals should be a list"
+  )
+})
+
+test_that(".print_globals() fetches globals when called without the globals arg", {
+  res <- testthat::with_mocked_bindings(
+    checkhelper:::.print_globals(path = "/tmp/anywhere", message = FALSE),
+    .get_no_visible = function(path, ...) NULL,
+    .package = "checkhelper"
+  )
+  expect_null(res)
+})
+
+test_that(".print_globals() emits 'no globalVariable detected' when message = TRUE", {
+  expect_message(
+    res <- testthat::with_mocked_bindings(
+      checkhelper:::.print_globals(path = "/tmp/anywhere"),
+      .get_no_visible = function(path, ...) NULL,
+      .package = "checkhelper"
+    ),
+    regexp = "no globalVariable"
+  )
+  expect_null(res)
+})
+
+# .get_notes(): importfrom branch (line 372) ---------------------------------
+
+test_that(".get_notes() extracts importfrom_function names from quoted suggestions", {
+  fake_check <- list(
+    notes = c(paste(
+      "* checking R code for possible problems ... NOTE",
+      "myfun: no visible global function definition for 'helper'",
+      "Consider adding",
+      "  importFrom(\"somepkg\", \"helper\")",
+      "to your NAMESPACE file.",
+      sep = "\n"
+    ))
+  )
+
+  res <- checkhelper:::.get_notes(path = "/tmp/anywhere", checks = fake_check)
+  expect_true(any(res$importfrom_function == "helper"))
+})
+
+# deprecated::print_globals(): bare call path (line 119) ---------------------
+
+test_that("deprecated print_globals() forwards to .print_globals when no globals arg", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+  res <- testthat::with_mocked_bindings(
+    suppressMessages(suppressWarnings(print_globals(path = "/tmp/anywhere"))),
+    .get_no_visible = function(path, ...) NULL,
+    .package = "checkhelper"
+  )
+  expect_null(res)
+})

--- a/tests/testthat/test-audit-tags-helpers.R
+++ b/tests/testthat/test-audit-tags-helpers.R
@@ -1,0 +1,113 @@
+# Coverage-targeted tests for the small audit_tags internals.
+
+local_pkg_for_block <- function(envir = parent.frame()) {
+  # Build a real roxygen2-parseable mini-package so we can extract blocks
+  # without a fragile mock of roxygen2's internal block class.
+  path <- tempfile("pkg-tags-")
+  dir.create(file.path(path, "R"), recursive = TRUE)
+  writeLines(
+    c(
+      "Package: tagslab",
+      "Title: t",
+      "Version: 0.0.0.9000",
+      "Authors@R: person('A', 'B', email = 'a@b.c', role = c('aut', 'cre'))",
+      "Description: tagslab is a fixture.",
+      "License: MIT + file LICENSE",
+      "Encoding: UTF-8"
+    ),
+    file.path(path, "DESCRIPTION")
+  )
+  withr::defer(unlink(path, recursive = TRUE), envir = envir)
+  path
+}
+
+write_R_file <- function(path, name, lines) {
+  writeLines(lines, file.path(path, "R", name))
+}
+
+parse_blocks <- function(path) {
+  getFromNamespace("parse_package", "roxygen2")(path, env = NULL)
+}
+
+test_that("block_has_return_tag() returns TRUE when @return is present", {
+  pkg <- local_pkg_for_block()
+  write_R_file(pkg, "a.R", c(
+    "#' Foo",
+    "#' @return an integer",
+    "#' @export",
+    "foo <- function() 1L"
+  ))
+
+  blocks <- parse_blocks(pkg)
+  res <- checkhelper:::block_has_return_tag(blocks[[1]])
+  expect_true(res)
+})
+
+test_that("block_has_return_tag() returns FALSE when there is neither @return nor @inherit", {
+  pkg <- local_pkg_for_block()
+  write_R_file(pkg, "a.R", c(
+    "#' Foo",
+    "#' @export",
+    "foo <- function() 1L"
+  ))
+
+  blocks <- parse_blocks(pkg)
+  res <- checkhelper:::block_has_return_tag(blocks[[1]])
+  expect_false(res)
+})
+
+test_that("block_has_return_tag() returns TRUE on bare @inherit (no fields = inherit all)", {
+  pkg <- local_pkg_for_block()
+  write_R_file(pkg, "a.R", c(
+    "#' Foo bar",
+    "#' @return an integer",
+    "foo <- function() 1L",
+    "",
+    "#' @inherit foo",
+    "#' @export",
+    "bar <- function() foo()"
+  ))
+
+  blocks <- parse_blocks(pkg)
+  has_inherit <- vapply(blocks, function(b) {
+    tags <- vapply(b[["tags"]], function(t) t[["tag"]], character(1))
+    "inherit" %in% tags
+  }, logical(1))
+  bar_block <- blocks[[which(has_inherit)[1L]]]
+
+  res <- checkhelper:::block_has_return_tag(bar_block)
+  expect_true(res)
+})
+
+test_that("topic_block_returns() skips topic blocks without an rdname / name / topic", {
+  # A synthetic topic block with no rdname / name and topic == "" should be
+  # silently skipped by topic_block_returns().
+  pkg <- local_pkg_for_block()
+  write_R_file(pkg, "a.R", c(
+    "#' Foo",
+    "#' @return an integer",
+    "foo <- function() 1L"
+  ))
+
+  blocks <- parse_blocks(pkg)
+  res <- checkhelper:::topic_block_returns(blocks)
+  expect_true(is.character(res))
+})
+
+test_that("unload_target_pkg() is a no-op on an empty / missing pkg_name", {
+  expect_silent(checkhelper:::unload_target_pkg(NULL, ns_before = character(0), search_before = character(0)))
+  expect_silent(checkhelper:::unload_target_pkg("", ns_before = character(0), search_before = character(0)))
+})
+
+test_that("unload_target_pkg() is a no-op when the package was already loaded before", {
+  # `tools` is in loadedNamespaces() by default in any R session. Passing
+  # it in ns_before means the function must not attempt to unload it.
+  ns_before <- loadedNamespaces()
+  search_before <- search()
+  expect_silent(checkhelper:::unload_target_pkg(
+    "tools",
+    ns_before = ns_before,
+    search_before = search_before
+  ))
+  expect_true("tools" %in% loadedNamespaces())
+})

--- a/tests/testthat/test-create_example_pkg.R
+++ b/tests/testthat/test-create_example_pkg.R
@@ -10,3 +10,36 @@ test_that("create_example_pkg works", {
     unlink(pkgdir, recursive = TRUE)
   }
 })
+
+# --- Coverage tests for the with_* flags ------------------------------------
+
+test_that("create_example_pkg(with_nonascii = TRUE) copies the non-ASCII fixture", {
+  skip_if_not_installed("usethis")
+  skip_if_not_installed("attachment")
+
+  pkgdir <- suppressMessages(create_example_pkg(with_nonascii = TRUE))
+  on.exit(unlink(dirname(pkgdir), recursive = TRUE), add = TRUE)
+
+  expect_true(file.exists(file.path(pkgdir, "R", "nonascii.R")))
+})
+
+test_that("create_example_pkg(with_undocumented_data = TRUE) writes a data/*.rda", {
+  skip_if_not_installed("usethis")
+  skip_if_not_installed("attachment")
+
+  pkgdir <- suppressMessages(create_example_pkg(with_undocumented_data = TRUE))
+  on.exit(unlink(dirname(pkgdir), recursive = TRUE), add = TRUE)
+
+  expect_true(file.exists(file.path(pkgdir, "data", "demo_dataset.rda")))
+})
+
+test_that("create_example_pkg() errors when the path already exists", {
+  existing <- tempfile("pre-existing-")
+  dir.create(existing)
+  on.exit(unlink(existing, recursive = TRUE), add = TRUE)
+
+  expect_error(
+    create_example_pkg(path = existing),
+    regexp = "already exists"
+  )
+})


### PR DESCRIPTION
## Summary

Targeted regression tests for previously-uncovered branches across the package. No source change; only new / extended testthat files. Coverage moves from **87.6 %** to **93.3 %** (+5.7 pts).

### Per-file delta (testable files only)

| File | Before | After | Δ |
|---|---:|---:|---:|
| `create_example_pkg.R` | 75.9 | 98.1 | +22.2 |
| `audit_dontrun.R` | 79.7 | 100.0 | +20.3 |
| `audit_citation.R` | 85.7 | 100.0 | +14.3 |
| `audit_dataset_doc.R` | 87.5 | 100.0 | +12.5 |
| `audit_description.R` | 88.9 | 99.0 | +10.1 |
| `audit_globals.R` | 89.9 | 100.0 | +10.1 |
| `deprecated.R` | 99.0 | 100.0 | +1.0 |
| `asciify_helpers.R` | 89.6 | 95.1 | +5.5 |
| `audit_tags.R` | 94.0 | 94.8 | +0.8 |
| `audit_ascii.R` | 96.8 | 96.8 | = (1 dead branch) |

Six files now at 100 %.

### What is intentionally NOT covered

Three files have a structural cost-per-test that does not fit a unit-test PR:

- `cran_check_unique.R` (69 %, 71 missed lines): exercising any branch needs a full `R CMD check` run per test (minutes).
- `audit_userspace.R` (90 %, 13 missed): every code path runs `devtools::test()` + `run_examples()` + `rcmdcheck()` + `build_vignettes()` end-to-end.
- `audit_check.R` (96 %, 3 missed): same cost argument, plus one branch is `utils::browseURL()` (no-side-effect-in-tests).

A few "dead-defensive" branches remain (e.g. `audit_description.R:57` is an `else` that `read.dcf(fields = ...)` can never reach). Not patched here: this PR is tests-only, no source change.

### New / extended test files

- New: `test-audit-globals-coverage.R`, `test-audit-tags-helpers.R`, `test-asciify-coverage.R`.
- Extended: `test-audit-citation.R`, `test-audit-dataset-doc.R`, `test-audit-description.R`, `test-audit-dontrun.R`, `test-create_example_pkg.R`.

## Test plan

- [x] Full `devtools::test()` suite green locally on the new tree.
- [x] `covr::package_coverage()` reports 93.31 % overall (was 87.56 %).
- [ ] CI matrix green (R-CMD-check + test-coverage upload to codecov.io).