### PR TITLE
chore(cran-prep): hand maintainer role to Vincent + mention check_n_covr in README

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,3 +18,4 @@
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
 ^CONTRIBUTING\.md$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ inst/doc
 /Meta/
 cran-comments.md
 CRAN-SUBMISSION
+.claude/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,10 @@ Package: checkhelper
 Title: Deal with Check Outputs
 Version: 1.0.0
 Authors@R: c(
-    person("Sebastien", "Rochette", , "sebastien@thinkr.fr", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0002-1565-9313")),
-    person("Vincent", "Guyader", , "vincent@thinkr.fr", role = "aut",
+    person("Vincent", "Guyader", , "vincent@thinkr.fr", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0671-9270")),
+    person("Sebastien", "Rochette", , "sebastien@thinkr.fr", role = "aut",
+           comment = c(ORCID = "0000-0002-1565-9313", "previous maintainer")),
     person("Arthur", "Bréant", , "arthur@thinkr.fr", role = "aut",
            comment = c(ORCID = "0000-0003-1668-0963")),
     person("Murielle", "Delmotte", , "murielle@thinkr.fr", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# checkhelper (development version)
+# checkhelper 1.0.0
 
 ## `check_n_covr()`: check plus coverage in a single test pass
 
@@ -235,9 +235,7 @@ The 10 historic functions remain callable but emit
   list element: the count of non-ASCII characters in the original
   file. `n_tokens` (number of source locations to rewrite) is kept.
 
-# checkhelper 1.0.0
-
-## New features
+## `asciify_*()` family: rewrite non-ASCII characters AST-aware
 
 - `asciify_pkg()`, `asciify_file()`, `asciify_r_source()`,
   `find_nonascii_tokens()` and `find_nonascii_files()` rewrite

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,6 +39,16 @@ Lower-level helpers (`asciify_file()`, `asciify_r_source()`, `find_nonascii_toke
 
 The 10 historic functions (`get_no_visible()`, `find_missing_tags()`, `asciify_pkg()`, `check_as_cran()`, …) remain callable but emit a `lifecycle::deprecate_warn()` and delegate to the new façades - see `NEWS.md` for the full mapping.
 
+## Faster local check: `check_n_covr()`
+
+`check_n_covr(pkg)` runs `R CMD check` (via `devtools::check(args = "--no-tests")`) and code coverage (via `covr::package_coverage(type = "tests")`) without running the unit-test suite twice. On a package with a slow test suite this roughly halves the wait. Returns a named list `list(check, coverage)`.
+
+```r
+res <- check_n_covr(".")
+res$check
+covr::percent_coverage(res$coverage)
+```
+
 ## Installation
 
 From CRAN:

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,7 +41,7 @@ The 10 historic functions (`get_no_visible()`, `find_missing_tags()`, `asciify_p
 
 ## Faster local check: `check_n_covr()`
 
-`check_n_covr(pkg)` runs `R CMD check` (via `devtools::check(args = "--no-tests")`) and code coverage (via `covr::package_coverage(type = "tests")`) without running the unit-test suite twice. On a package with a slow test suite this roughly halves the wait. Returns a named list `list(check, coverage)`.
+`check_n_covr(pkg)` runs `R CMD check` (via `devtools::check(args = "--no-tests")`) and code coverage (via `covr::package_coverage(type = "tests")`) without running the unit-test suite twice. On a package with a slow test suite this roughly halves the wait. Returns a named list `list(check = ..., coverage = ...)`.
 
 ```r
 res <- check_n_covr(".")

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ The 10 historic functions (`get_no_visible()`, `find_missing_tags()`,
 `lifecycle::deprecate_warn()` and delegate to the new façades - see
 `NEWS.md` for the full mapping.
 
+## Faster local check: `check_n_covr()`
+
+`check_n_covr(pkg)` runs `R CMD check` (via
+`devtools::check(args = "--no-tests")`) and code coverage (via
+`covr::package_coverage(type = "tests")`) without running the unit-test
+suite twice. On a package with a slow test suite this roughly halves the
+wait. Returns a named list `list(check, coverage)`.
+
+``` r
+res <- check_n_covr(".")
+res$check
+covr::percent_coverage(res$coverage)
+```
+
 ## Installation
 
 From CRAN:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The 10 historic functions (`get_no_visible()`, `find_missing_tags()`,
 `devtools::check(args = "--no-tests")`) and code coverage (via
 `covr::package_coverage(type = "tests")`) without running the unit-test
 suite twice. On a package with a slow test suite this roughly halves the
-wait. Returns a named list `list(check, coverage)`.
+wait. Returns a named list `list(check = ..., coverage = ...)`.
 
 ``` r
 res <- check_n_covr(".")


### PR DESCRIPTION
## Summary
- DESCRIPTION: Vincent Guyader becomes `c(\"aut\", \"cre\")`; Sebastien Rochette keeps `\"aut\"` and gains a `previous maintainer` note in `comment =` (mirrors the pattern used in {golem}).
- README (Rmd + md): short section documenting `check_n_covr()` between the API table and the Installation block, so the new helper is visible from the landing page.

## Test plan
- [ ] R CMD check --as-cran clean (0/0/0)
- [ ] pkgdown build still surfaces `check_n_covr` under Audit