### PR TITLE
chore(cran): track cran-comments.md + regenerate package Rd after maintainer swap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@
 inst/doc
 /doc/
 /Meta/
-cran-comments.md
 CRAN-SUBMISSION
 .claude/

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,34 @@
+## Submission summary
+
+This is a feature release of {checkhelper} (1.0.0). The previous CRAN
+version was 0.1.0. The release introduces a uniform `audit_*` /
+`fix_*` API for CRAN-blocking issues (globals, roxygen tags,
+non-ASCII, userspace leaks, CRAN-settings checks, undocumented
+datasets, old-style CITATION, `\dontrun{}` blocks, unquoted package
+names in DESCRIPTION, network/download calls) plus a one-pass
+`check_n_covr()` helper. The 10 historic functions remain callable
+behind `lifecycle::deprecate_warn()` and delegate to the new
+facades, so no reverse dependency breaks. See `NEWS.md` for the
+full mapping.
+
+The maintainer changes from Sebastien Rochette to Vincent Guyader.
+Sebastien Rochette stays in `Authors@R` with a `previous maintainer`
+note in `comment =`.
+
+## Test environments
+
+* local: Ubuntu Linux, R-release
+* GitHub Actions: ubuntu-latest, macos-latest, windows-latest
+  (R-release and R-devel)
+* win-builder: R-release and R-devel
+
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+## Reverse dependencies
+
+We checked the reverse dependencies of {checkhelper} on CRAN. No
+breakage detected: the deprecated functions still dispatch to the
+new facades with a `lifecycle::deprecate_warn()` and an unchanged
+return shape.

--- a/man/checkhelper-package.Rd
+++ b/man/checkhelper-package.Rd
@@ -18,11 +18,11 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Sebastien Rochette \email{sebastien@thinkr.fr} (\href{https://orcid.org/0000-0002-1565-9313}{ORCID})
+\strong{Maintainer}: Vincent Guyader \email{vincent@thinkr.fr} (\href{https://orcid.org/0000-0003-0671-9270}{ORCID})
 
 Authors:
 \itemize{
-  \item Vincent Guyader \email{vincent@thinkr.fr} (\href{https://orcid.org/0000-0003-0671-9270}{ORCID})
+  \item Sebastien Rochette \email{sebastien@thinkr.fr} (\href{https://orcid.org/0000-0002-1565-9313}{ORCID}) (previous maintainer)
   \item Arthur Bréant \email{arthur@thinkr.fr} (\href{https://orcid.org/0000-0003-1668-0963}{ORCID})
   \item Murielle Delmotte \email{murielle@thinkr.fr} (\href{https://orcid.org/0000-0002-1339-2424}{ORCID})
 }


### PR DESCRIPTION
## Summary

Two follow-ups to #121 that I pushed after the squash-merge had already happened, so they did not land on `main`:

- `cran-comments.md` is now tracked in git (removed from `.gitignore`) with an initial 1.0.0 draft. Rationale: its content is what gets pasted into the CRAN submission form's "Optional comment" field; it stays out of the tarball via `.Rbuildignore` but it travels with the submission, so it belongs in git.
- `man/checkhelper-package.Rd` regenerated by roxygen2 to reflect the maintainer swap landed in #121 (Vincent Guyader on the Maintainer line; Sebastien Rochette in Authors with a `(previous maintainer)` suffix).

The branch `chore/cran-prep-maintainer` still has these commits but is otherwise post-merge; once this PR lands, that branch can be deleted.

## Test plan
- [ ] `R CMD check --as-cran` still 0/0/0 on real findings
- [ ] `cran-comments.md` content reviewed and tweaked before `devtools::release()`